### PR TITLE
Fix updating tokens_staked of Artifact

### DIFF
--- a/js/lib/src/instructions/staking.ts
+++ b/js/lib/src/instructions/staking.ts
@@ -5,7 +5,7 @@ import {
 } from "@raindrop-studios/sol-kit";
 import { Token } from "@solana/spl-token";
 import { SystemProgram } from "@solana/web3.js";
-import { TOKEN_PROGRAM_ID } from "../constants/programIds";
+import { ITEM_ID, PLAYER_ID, TOKEN_PROGRAM_ID } from "../constants/programIds";
 import { ContractCommon } from "../contract/common";
 import { AnchorPermissivenessType } from "../state/common";
 import {
@@ -211,10 +211,13 @@ export class Instruction extends SolKitInstruction {
           stakingMint: accounts.stakingMint,
           payer: (this.program.client.provider as AnchorProvider).wallet
             .publicKey,
+          itemProgram: ITEM_ID,
+          playerProgram: PLAYER_ID,
           systemProgram: SystemProgram.programId,
           tokenProgram: TOKEN_PROGRAM_ID,
           rent: web3.SYSVAR_RENT_PUBKEY,
           clock: web3.SYSVAR_CLOCK_PUBKEY,
+          instructionSysvarAccount: web3.SYSVAR_INSTRUCTIONS_PUBKEY,
         })
         .instruction(),
     ];
@@ -280,10 +283,13 @@ export class Instruction extends SolKitInstruction {
           stakingMint: accounts.stakingMint,
           payer: (this.program.client.provider as AnchorProvider).wallet
             .publicKey,
+          itemProgram: ITEM_ID,
+          playerProgram: PLAYER_ID,
           systemProgram: SystemProgram.programId,
           tokenProgram: TOKEN_PROGRAM_ID,
           rent: web3.SYSVAR_RENT_PUBKEY,
           clock: web3.SYSVAR_CLOCK_PUBKEY,
+          instructionSysvarAccount: web3.SYSVAR_INSTRUCTIONS_PUBKEY,
         })
         .remainingAccounts(remainingAccounts)
         .instruction(),

--- a/rust/staking/Cargo.toml
+++ b/rust/staking/Cargo.toml
@@ -18,9 +18,9 @@ default = []
 anchor-lang ={ version = "0.24.2", features = ["init-if-needed"] }
 anchor-spl = "0.24.2"
 arrayref = "0.3.6"
-spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
-spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
-metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
-raindrops-namespace = { features = [ "no-entrypoint" ], path = "../namespace" }
-raindrops-item = { features = [ "no-entrypoint" ], path = "../item" }
-raindrops-player = { features = [ "no-entrypoint" ], path = "../player" }
+spl-associated-token-account = { version="1.0.3", features = ["no-entrypoint"] }
+spl-token = { version="3.1.1", features = ["no-entrypoint"] }
+metaplex-token-metadata = { version="0.0.1", features = ["no-entrypoint"] }
+raindrops-namespace = { features = ["no-entrypoint"], path = "../namespace" }
+raindrops-item = { features = ["cpi", "no-entrypoint"], path = "../item" }
+raindrops-player = { features = ["no-entrypoint"], path = "../player" }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+edition = "2018"
+group_imports = "Preserve"
+imports_granularity = "Crate"
+imports_indent = "Block"
+max_width = 100
+reorder_impl_items = false
+reorder_imports = true
+reorder_modules = true


### PR DESCRIPTION
### Description

This PR covers:
- Added `update_tokens_staked` instruction to `item` program.
- Added calling `update_tokens_staked` cpi to update `tokens_staked` of Artifact.
- Restricted `update_tokens_staked` cpi calling that can only be called by `staking` program.

### Test Plan

begin_artifact_stake_warmup:
`npx ts-node js/cli/src/staking.ts begin_artifact_stake_warmup -k ~/.config/solana/id.json -e devnet -cp js/cli/example-configs/staking/stake.json`

end_artifact_stake_warmup:
`npx ts-node js/cli/src/staking.ts end_artifact_stake_warmup -k ~/.config/solana/id.json -e devnet -cp js/cli/example-configs/staking/stake.json`