### PR TITLE
CPI Crate Example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+copy_idls: copy_namespace_idl copy_item_idl copy_matches_idl copy_player_idl copy_staking_idl
+
+copy_namespace_idl:
+	cp rust/target/idl/namespace.json rust/namespace-cpi
+
+copy_item_idl:
+	cp rust/target/idl/item.json rust/item-cpi
+
+copy_matches_idl:
+	cp rust/target/idl/matches.json rust/matches-cpi
+
+copy_player_idl:
+	cp rust/target/idl/player.json rust/player-cpi
+
+copy_staking_idl:
+	cp rust/target/idl/staking.json rust/staking-cpi

--- a/js/lib/src/constants/programIds.ts
+++ b/js/lib/src/constants/programIds.ts
@@ -1,11 +1,11 @@
 import { web3 } from "@project-serum/anchor";
 
 export const NAMESPACE_ID = new web3.PublicKey(
-  "nameAxQRRBnd4kLfsVoZBBXfrByZdZTkh8mULLxLyqV"
+  "AguQatwNFEaZSFUHsTj5fcU3LdsNFQLrYSHQjZ4erC8X"
 );
 
 export const ITEM_ID = new web3.PublicKey(
-  "itemX1XWs9dK8T2Zca4vEEPfCAhRc7yvYFntPjTTVx6"
+  "CKAcdJsyzBxHJRHgKVEsVzjX9SNcvut8t3PUD34g7ry4"
 );
 
 export const PLAYER_ID = new web3.PublicKey(

--- a/rust/Anchor.toml
+++ b/rust/Anchor.toml
@@ -27,7 +27,7 @@ staking = "stk9HFnKhZN2PZjnn5C4wTzmeiAEgsDkbqnHkNjX1Z4"
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 
 [workspace]
-members = ["item", "namespace", "matches", "staking"]
+members = ["item", "namespace", "matches", "staking", "player"]
 
 [test.validator]
 url = "https://devnet.genesysgo.net/"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1037,7 +1037,9 @@ dependencies = [
  "anchor-spl",
  "arrayref",
  "metaplex-token-metadata",
- "raindrops-item-cpi",
+ "raindrops-item",
+ "raindrops-matches",
+ "raindrops-player",
  "spl-associated-token-account",
  "spl-token",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -708,14 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "item-cpi"
-version = "0.1.0"
-dependencies = [
- "anchor-gen",
- "anchor-lang",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,9 +996,17 @@ dependencies = [
  "anchor-spl",
  "arrayref",
  "metaplex-token-metadata",
- "raindrops-namespace",
+ "raindrops-namespace-cpi",
  "spl-associated-token-account",
  "spl-token",
+]
+
+[[package]]
+name = "raindrops-item-cpi"
+version = "0.1.0"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang",
 ]
 
 [[package]]
@@ -1016,10 +1016,17 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "arrayref",
- "metaplex-token-metadata",
- "raindrops-namespace",
+ "raindrops-namespace-cpi",
  "spl-associated-token-account",
  "spl-token",
+]
+
+[[package]]
+name = "raindrops-matches-cpi"
+version = "0.1.0"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang",
 ]
 
 [[package]]
@@ -1029,10 +1036,18 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "arrayref",
- "item-cpi",
  "metaplex-token-metadata",
+ "raindrops-item-cpi",
  "spl-associated-token-account",
  "spl-token",
+]
+
+[[package]]
+name = "raindrops-namespace-cpi"
+version = "0.1.0"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang",
 ]
 
 [[package]]
@@ -1043,9 +1058,17 @@ dependencies = [
  "anchor-spl",
  "arrayref",
  "metaplex-token-metadata",
- "raindrops-namespace",
+ "raindrops-namespace-cpi",
  "spl-associated-token-account",
  "spl-token",
+]
+
+[[package]]
+name = "raindrops-player-cpi"
+version = "0.1.0"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang",
 ]
 
 [[package]]
@@ -1057,7 +1080,7 @@ dependencies = [
  "arrayref",
  "metaplex-token-metadata",
  "raindrops-item",
- "raindrops-namespace",
+ "raindrops-namespace-cpi",
  "raindrops-player",
  "spl-associated-token-account",
  "spl-token",
@@ -1355,6 +1378,14 @@ dependencies = [
  "num_enum",
  "solana-program",
  "thiserror",
+]
+
+[[package]]
+name = "staking-cpi"
+version = "0.1.0"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "d104aa17418cb329ed7418b227e083d5f326a27f26ce98f5d92e33da62a5f459"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -132,6 +132,52 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-gen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82c66ee428b58005d2f2e3a8f3f795a83ee77e0ae92634f2f10d38e8223be413"
+dependencies = [
+ "anchor-generate-cpi-crate",
+ "anchor-generate-cpi-interface",
+]
+
+[[package]]
+name = "anchor-generate-cpi-crate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df80faf78057bc25344432f9ba0187a08591b2c5b17c8094a2604df7ef7a77c0"
+dependencies = [
+ "anchor-idl",
+ "syn",
+]
+
+[[package]]
+name = "anchor-generate-cpi-interface"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d8f3399fd9a9198fa161ff6b0e7f789fdfffc66f74f2d0bfcbc4c0cb5de74e4"
+dependencies = [
+ "anchor-idl",
+ "darling",
+ "syn",
+]
+
+[[package]]
+name = "anchor-idl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d40b28558607ed4db368939b8abfe5c45ebad13bdce5236b1222955b1e88be"
+dependencies = [
+ "anchor-syn",
+ "darling",
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
  "syn",
 ]
 
@@ -179,7 +225,7 @@ checksum = "03549dc2eae0b20beba6333b14520e511822a6321cdb1760f841064a69347316"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -476,6 +522,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +603,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,12 +693,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "item-cpi"
+version = "0.1.0"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang",
 ]
 
 [[package]]
@@ -860,11 +967,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -882,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -897,6 +1004,7 @@ dependencies = [
  "anchor-spl",
  "arrayref",
  "metaplex-token-metadata",
+ "raindrops-namespace",
  "spl-associated-token-account",
  "spl-token",
 ]
@@ -921,8 +1029,8 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "arrayref",
+ "item-cpi",
  "metaplex-token-metadata",
- "raindrops-item",
  "spl-associated-token-account",
  "spl-token",
 ]
@@ -1086,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1250,6 +1358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,13 +1371,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1311,16 +1425,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "item/",
+  "item-cpi/",
   "player/",
   "namespace/",
   "matches/",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,9 +3,13 @@ members = [
   "item/",
   "item-cpi/",
   "player/",
+  "player-cpi/",
   "namespace/",
+  "namespace-cpi/",
   "matches/",
-  "staking/"
+  "matches-cpi/",
+  "staking/",
+  "staking-cpi/"
 ]
 exclude = [
 ]

--- a/rust/item-cpi/Cargo.toml
+++ b/rust/item-cpi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "item-cpi"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["cpi"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+
+[dependencies]
+anchor-gen = { version = "0.3.0" }
+anchor-lang = "0.24.2"

--- a/rust/item-cpi/item.json
+++ b/rust/item-cpi/item.json
@@ -2331,30 +2331,6 @@
       }
     },
     {
-      "name": "NamespaceAndIndex",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "namespace",
-            "type": "publicKey"
-          },
-          {
-            "name": "index",
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
-            "name": "inherited",
-            "type": {
-              "defined": "InheritanceState"
-            }
-          }
-        ]
-      }
-    },
-    {
       "name": "DNPItem",
       "type": {
         "kind": "struct",
@@ -2947,23 +2923,6 @@
           }
         ]
       }
-    },
-    {
-      "name": "InheritanceState",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "NotInherited"
-          },
-          {
-            "name": "Inherited"
-          },
-          {
-            "name": "Overridden"
-          }
-        ]
-      }
     }
   ],
   "errors": [
@@ -3297,8 +3256,5 @@
       "name": "MustBeCalledByStakingProgram",
       "msg": "Must be called by staking program"
     }
-  ],
-  "metadata": {
-    "address": "CKAcdJsyzBxHJRHgKVEsVzjX9SNcvut8t3PUD34g7ry4"
-  }
+  ]
 }

--- a/rust/item-cpi/item.json
+++ b/rust/item-cpi/item.json
@@ -1,0 +1,3304 @@
+{
+  "version": "0.1.0",
+  "name": "item",
+  "instructions": [
+    {
+      "name": "createItemClass",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "itemMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "metadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "edition",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "parent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "CreateItemClassArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateItemClass",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "itemMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "parent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "UpdateItemClassArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "drainItemClass",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "parentClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "receiver",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "DrainItemClassArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "drainItem",
+      "accounts": [
+        {
+          "name": "item",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "receiver",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "DrainItemArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "createItemEscrow",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemClassMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemEdition",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newItemToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemTokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "CreateItemEscrowArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "addCraftItemToEscrow",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemCounter",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newItemToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemTokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemTokenAccountEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemTokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItem",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "AddCraftItemToEscrowArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "removeCraftItemFromEscrow",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemCounter",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newItemToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemTokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemTokenAccountEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItem",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "craftItemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "receiver",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "RemoveCraftItemFromEscrowArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "startItemEscrowBuildPhase",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newItemToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemTokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "StartItemEscrowBuildPhaseArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "completeItemEscrowBuildPhase",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newItem",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newItemMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemEdition",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newItemToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newItemTokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "CompleteItemEscrowBuildPhaseArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateItem",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "item",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "UpdateItemArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "deactivateItemEscrow",
+      "accounts": [
+        {
+          "name": "itemEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "originator",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "DeactivateItemEscrowArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "drainItemEscrow",
+      "accounts": [
+        {
+          "name": "itemEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "originator",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "DrainItemEscrowArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "beginItemActivation",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "item",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "itemMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "itemTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "itemActivationMarker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "playerProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "validationProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "BeginItemActivationArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "endItemActivation",
+      "accounts": [
+        {
+          "name": "item",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemActivationMarker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "receiver",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "EndItemActivationArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "resetStateValidationForActivation",
+      "accounts": [
+        {
+          "name": "item",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemActivationMarker",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ResetStateValidationForActivationArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateValidForUseIfWarmupPassed",
+      "accounts": [
+        {
+          "name": "item",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemActivationMarker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "UpdateValidForUseIfWarmupPassedArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "proveNewStateValid",
+      "accounts": [
+        {
+          "name": "item",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemActivationMarker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProveNewStateValidArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "itemClassJoinNamespace",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespace",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "itemClassLeaveNamespace",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespace",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "itemClassCacheNamespace",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespace",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "page",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "itemClassUncacheNamespace",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespace",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateTokensStaked",
+      "accounts": [
+        {
+          "name": "item",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "UpdateTokensStakedArgs"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ItemClass",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "parent",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "mint",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "metadata",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "edition",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "existingChildren",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "deactivated",
+            "type": "bool"
+          },
+          {
+            "name": "step",
+            "type": "u64"
+          },
+          {
+            "name": "timeToBuild",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "buildBegan",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CraftItemCounter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amountLoaded",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemActivationMarker",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "validForUse",
+            "type": "bool"
+          },
+          {
+            "name": "amount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "unixTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "proofCounter",
+            "type": {
+              "option": {
+                "defined": "ItemActivationMarkerProofCounter"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Item",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "type": "u8"
+          },
+          {
+            "name": "parent",
+            "type": "publicKey"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "mint",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "metadata",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "edition",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "tokensStaked",
+            "type": "u64"
+          },
+          {
+            "name": "data",
+            "type": {
+              "defined": "ItemData"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "CreateItemClassArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "parentOfParentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "space",
+            "type": "u64"
+          },
+          {
+            "name": "desiredNamespaceArraySize",
+            "type": "u16"
+          },
+          {
+            "name": "updatePermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "storeMint",
+            "type": "bool"
+          },
+          {
+            "name": "storeMetadataFields",
+            "type": "bool"
+          },
+          {
+            "name": "itemClassData",
+            "type": {
+              "defined": "ItemClassData"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DrainItemClassArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "updatePermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateItemClassArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "updatePermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "itemClassData",
+            "type": {
+              "option": {
+                "defined": "ItemClassData"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DrainItemArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "itemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "updatePermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateItemEscrowArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "craftEscrowIndex",
+            "type": "u64"
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "amountToMake",
+            "type": "u64"
+          },
+          {
+            "name": "namespaceIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "buildPermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddCraftItemToEscrowArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "craftItemIndex",
+            "type": "u64"
+          },
+          {
+            "name": "craftItemClassIndex",
+            "type": "u64"
+          },
+          {
+            "name": "craftItemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "craftEscrowIndex",
+            "type": "u64"
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "amountToMake",
+            "type": "u64"
+          },
+          {
+            "name": "amountToContributeFromThisContributor",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "newItemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "originator",
+            "type": "publicKey"
+          },
+          {
+            "name": "buildPermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "componentProof",
+            "type": {
+              "option": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "component",
+            "type": {
+              "option": {
+                "defined": "Component"
+              }
+            }
+          },
+          {
+            "name": "craftUsageInfo",
+            "type": {
+              "option": {
+                "defined": "CraftUsageInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StartItemEscrowBuildPhaseArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "craftEscrowIndex",
+            "type": "u64"
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "amountToMake",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "originator",
+            "type": "publicKey"
+          },
+          {
+            "name": "newItemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "buildPermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "endNodeProof",
+            "type": {
+              "option": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "totalSteps",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CompleteItemEscrowBuildPhaseArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "newItemIndex",
+            "type": "u64"
+          },
+          {
+            "name": "craftEscrowIndex",
+            "type": "u64"
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "amountToMake",
+            "type": "u64"
+          },
+          {
+            "name": "space",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "originator",
+            "type": "publicKey"
+          },
+          {
+            "name": "buildPermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "storeMint",
+            "type": "bool"
+          },
+          {
+            "name": "storeMetadataFields",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateItemArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "itemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DeactivateItemEscrowArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "craftEscrowIndex",
+            "type": "u64"
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "amountToMake",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "newItemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "newItemToken",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DrainItemEscrowArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "craftEscrowIndex",
+            "type": "u64"
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "amountToMake",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "newItemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "newItemToken",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveCraftItemFromEscrowArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "craftItemIndex",
+            "type": "u64"
+          },
+          {
+            "name": "craftEscrowIndex",
+            "type": "u64"
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "amountToMake",
+            "type": "u64"
+          },
+          {
+            "name": "amountContributedFromThisContributor",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "newItemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "originator",
+            "type": "publicKey"
+          },
+          {
+            "name": "craftItemTokenMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "craftItemClassIndex",
+            "type": "u64"
+          },
+          {
+            "name": "craftItemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "buildPermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "componentProof",
+            "type": {
+              "option": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "component",
+            "type": {
+              "option": {
+                "defined": "Component"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BeginItemActivationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "itemMarkerSpace",
+            "type": "u8"
+          },
+          {
+            "name": "usagePermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "usageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "usageInfo",
+            "type": {
+              "option": {
+                "defined": "UsageInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ValidationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "instruction",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "extraIdentifier",
+            "type": "u64"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "usagePermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "usageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "usageInfo",
+            "type": {
+              "option": {
+                "defined": "UsageInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProveNewStateValidArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "usageStateProofs",
+            "type": {
+              "vec": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "newUsageStateProofs",
+            "type": {
+              "vec": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "usageStates",
+            "type": {
+              "vec": {
+                "defined": "ItemUsageState"
+              }
+            }
+          },
+          {
+            "name": "itemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "usageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "usageProof",
+            "type": {
+              "option": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "usage",
+            "type": {
+              "option": {
+                "defined": "ItemUsage"
+              }
+            }
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ResetStateValidationForActivationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "itemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "usageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "usageInfo",
+            "type": {
+              "option": {
+                "defined": "UsageInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateValidForUseIfWarmupPassedArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "itemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "usageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "usageProof",
+            "type": {
+              "option": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "usage",
+            "type": {
+              "option": {
+                "defined": "ItemUsage"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EndItemActivationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "itemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "usagePermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "usageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "usageProof",
+            "type": {
+              "option": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "usage",
+            "type": {
+              "option": {
+                "defined": "ItemUsage"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateTokensStakedArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "itemMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "staked",
+            "type": "bool"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Callback",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": "publicKey"
+          },
+          {
+            "name": "code",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemUsage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "basicItemEffects",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "BasicItemEffect"
+                }
+              }
+            }
+          },
+          {
+            "name": "usagePermissiveness",
+            "type": {
+              "vec": {
+                "defined": "PermissivenessType"
+              }
+            }
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          },
+          {
+            "name": "itemClassType",
+            "type": {
+              "defined": "ItemClassType"
+            }
+          },
+          {
+            "name": "callback",
+            "type": {
+              "option": {
+                "defined": "Callback"
+              }
+            }
+          },
+          {
+            "name": "validation",
+            "type": {
+              "option": {
+                "defined": "Callback"
+              }
+            }
+          },
+          {
+            "name": "doNotPairWithSelf",
+            "type": "bool"
+          },
+          {
+            "name": "dnp",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "DNPItem"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemUsageState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "uses",
+            "type": "u64"
+          },
+          {
+            "name": "activatedAt",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BasicItemEffect",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "stat",
+            "type": "string"
+          },
+          {
+            "name": "itemEffectType",
+            "type": {
+              "defined": "BasicItemEffectType"
+            }
+          },
+          {
+            "name": "activeDuration",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingAmountNumerator",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingAmountDivisor",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingDurationNumerator",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingDurationDivisor",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "maxUses",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Component",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timeToBuild",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "componentScope",
+            "type": "string"
+          },
+          {
+            "name": "useUsageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "condition",
+            "type": {
+              "defined": "ComponentCondition"
+            }
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permissiveness",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          },
+          {
+            "name": "permissivenessType",
+            "type": {
+              "defined": "PermissivenessType"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChildUpdatePropagationPermissiveness",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "overridable",
+            "type": "bool"
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          },
+          {
+            "name": "childUpdatePropagationPermissivenessType",
+            "type": {
+              "defined": "ChildUpdatePropagationPermissivenessType"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NamespaceAndIndex",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespace",
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DNPItem",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": "publicKey"
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Root",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          },
+          {
+            "name": "root",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Boolean",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          },
+          {
+            "name": "boolean",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemClassSettings",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "freeBuild",
+            "type": {
+              "option": {
+                "defined": "Boolean"
+              }
+            }
+          },
+          {
+            "name": "childrenMustBeEditions",
+            "type": {
+              "option": {
+                "defined": "Boolean"
+              }
+            }
+          },
+          {
+            "name": "builderMustBeHolder",
+            "type": {
+              "option": {
+                "defined": "Boolean"
+              }
+            }
+          },
+          {
+            "name": "updatePermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "buildPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "stakingWarmUpDuration",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingCooldownDuration",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "unstakingPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "childUpdatePropagationPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "ChildUpdatePropagationPermissiveness"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemClassConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "usageRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "usageStateRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "componentRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "usages",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "ItemUsage"
+                }
+              }
+            }
+          },
+          {
+            "name": "components",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Component"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemClassData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "settings",
+            "type": {
+              "defined": "ItemClassSettings"
+            }
+          },
+          {
+            "name": "config",
+            "type": {
+              "defined": "ItemClassConfig"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemActivationMarkerProofCounter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "statesProven",
+            "type": "u16"
+          },
+          {
+            "name": "statesRequired",
+            "type": "u16"
+          },
+          {
+            "name": "ignoreIndex",
+            "type": "u16"
+          },
+          {
+            "name": "newStateRoot",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "usageStateRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "usageStates",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "ItemUsageState"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CraftUsageInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "craftUsageStateProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "craftUsageState",
+            "type": {
+              "defined": "ItemUsageState"
+            }
+          },
+          {
+            "name": "craftUsageProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "craftUsage",
+            "type": {
+              "defined": "ItemUsage"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UsageInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "usageProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "usage",
+            "type": {
+              "defined": "ItemUsage"
+            }
+          },
+          {
+            "name": "usageStateProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "usageState",
+            "type": {
+              "defined": "ItemUsageState"
+            }
+          },
+          {
+            "name": "newUsageStateProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "newUsageStateRoot",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "totalStates",
+            "type": "u16"
+          },
+          {
+            "name": "totalStatesProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "newTotalStatesProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemClassType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Wearable",
+            "fields": [
+              {
+                "name": "body_part",
+                "type": {
+                  "vec": "string"
+                }
+              },
+              {
+                "name": "limit_per_part",
+                "type": {
+                  "option": "u64"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Consumable",
+            "fields": [
+              {
+                "name": "max_uses",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "max_players_per_use",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "item_usage_type",
+                "type": {
+                  "defined": "ItemUsageType"
+                }
+              },
+              {
+                "name": "cooldown_duration",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "warmup_duration",
+                "type": {
+                  "option": "u64"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "ItemUsageType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Exhaustion"
+          },
+          {
+            "name": "Destruction"
+          },
+          {
+            "name": "Infinite"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BasicItemEffectType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Increment"
+          },
+          {
+            "name": "Decrement"
+          },
+          {
+            "name": "IncrementPercent"
+          },
+          {
+            "name": "DecrementPercent"
+          },
+          {
+            "name": "IncrementPercentFromBase"
+          },
+          {
+            "name": "DecrementPercentFromBase"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ComponentCondition",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Consumed"
+          },
+          {
+            "name": "Presence"
+          },
+          {
+            "name": "Absence"
+          },
+          {
+            "name": "Cooldown"
+          },
+          {
+            "name": "CooldownAndConsume"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissivenessType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenHolder"
+          },
+          {
+            "name": "ParentTokenHolder"
+          },
+          {
+            "name": "UpdateAuthority"
+          },
+          {
+            "name": "Anybody"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChildUpdatePropagationPermissivenessType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Usages"
+          },
+          {
+            "name": "Components"
+          },
+          {
+            "name": "UpdatePermissiveness"
+          },
+          {
+            "name": "BuildPermissiveness"
+          },
+          {
+            "name": "ChildUpdatePropagationPermissiveness"
+          },
+          {
+            "name": "ChildrenMustBeEditionsPermissiveness"
+          },
+          {
+            "name": "BuilderMustBeHolderPermissiveness"
+          },
+          {
+            "name": "StakingPermissiveness"
+          },
+          {
+            "name": "Namespaces"
+          },
+          {
+            "name": "FreeBuildPermissiveness"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InheritanceState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NotInherited"
+          },
+          {
+            "name": "Inherited"
+          },
+          {
+            "name": "Overridden"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "IncorrectOwner",
+      "msg": "Account does not have correct owner!"
+    },
+    {
+      "code": 6001,
+      "name": "Uninitialized",
+      "msg": "Account is not initialized!"
+    },
+    {
+      "code": 6002,
+      "name": "MintMismatch",
+      "msg": "Mint Mismatch!"
+    },
+    {
+      "code": 6003,
+      "name": "TokenTransferFailed",
+      "msg": "Token transfer failed"
+    },
+    {
+      "code": 6004,
+      "name": "NumericalOverflowError",
+      "msg": "Numerical overflow error"
+    },
+    {
+      "code": 6005,
+      "name": "TokenMintToFailed",
+      "msg": "Token mint to failed"
+    },
+    {
+      "code": 6006,
+      "name": "TokenBurnFailed",
+      "msg": "TokenBurnFailed"
+    },
+    {
+      "code": 6007,
+      "name": "DerivedKeyInvalid",
+      "msg": "Derived key is invalid"
+    },
+    {
+      "code": 6008,
+      "name": "MustSpecifyPermissivenessType",
+      "msg": "Must specify permissiveness type"
+    },
+    {
+      "code": 6009,
+      "name": "PermissivenessNotFound",
+      "msg": "Permissiveness not found in array"
+    },
+    {
+      "code": 6010,
+      "name": "PublicKeyMismatch",
+      "msg": "Public key mismatch"
+    },
+    {
+      "code": 6011,
+      "name": "InsufficientBalance",
+      "msg": "Insufficient Balance"
+    },
+    {
+      "code": 6012,
+      "name": "MetadataDoesntExist",
+      "msg": "Metadata doesn't exist"
+    },
+    {
+      "code": 6013,
+      "name": "EditionDoesntExist",
+      "msg": "Edition doesn't exist"
+    },
+    {
+      "code": 6014,
+      "name": "NoParentPresent",
+      "msg": "No parent present"
+    },
+    {
+      "code": 6015,
+      "name": "ExpectedParent",
+      "msg": "Expected parent"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidMintAuthority",
+      "msg": "Invalid mint authority"
+    },
+    {
+      "code": 6017,
+      "name": "NotMintAuthority",
+      "msg": "Not mint authority"
+    },
+    {
+      "code": 6018,
+      "name": "CannotMakeZero",
+      "msg": "Cannot make zero of an item"
+    },
+    {
+      "code": 6019,
+      "name": "MustBeHolderToBuild",
+      "msg": "Must be token holder to build against it"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidConfigForFungibleMints",
+      "msg": "This config is invalid for fungible mints"
+    },
+    {
+      "code": 6021,
+      "name": "MissingMerkleInfo",
+      "msg": "Missing the merkle fields"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidProof",
+      "msg": "Invalid proof"
+    },
+    {
+      "code": 6023,
+      "name": "ItemReadyForCompletion",
+      "msg": "Item ready for completion"
+    },
+    {
+      "code": 6024,
+      "name": "MustUseMerkleOrComponentList",
+      "msg": "In order for crafting to work there must be either a component list or a component merkle root"
+    },
+    {
+      "code": 6025,
+      "name": "MustUseMerkleOrUsageState",
+      "msg": "In order for crafting to work there must be either a usage state list on the craft component or a usage merkle root"
+    },
+    {
+      "code": 6026,
+      "name": "UnableToFindValidCooldownState",
+      "msg": "Unable to find a valid cooldown state"
+    },
+    {
+      "code": 6027,
+      "name": "BalanceNeedsToBeZero",
+      "msg": "Balance needs to be zero"
+    },
+    {
+      "code": 6028,
+      "name": "NotPartOfComponentScope",
+      "msg": "This component is not part of this escrow's component scope"
+    },
+    {
+      "code": 6029,
+      "name": "TimeToBuildMismatch",
+      "msg": "The time to build on two disparate components in the same scope is different. Either unset one or make them both the same."
+    },
+    {
+      "code": 6030,
+      "name": "StakingMintNotWhitelisted",
+      "msg": "This staking mint has not been whitelisted in this namespace"
+    },
+    {
+      "code": 6031,
+      "name": "BuildPhaseNotStarted",
+      "msg": "Build phase not started"
+    },
+    {
+      "code": 6032,
+      "name": "BuildPhaseNotFinished",
+      "msg": "Build phase not finished"
+    },
+    {
+      "code": 6033,
+      "name": "DeactivatedItemEscrow",
+      "msg": "Item escrow has been deactivated"
+    },
+    {
+      "code": 6034,
+      "name": "BuildPhaseAlreadyStarted",
+      "msg": "Build phase already started"
+    },
+    {
+      "code": 6035,
+      "name": "StillMissingComponents",
+      "msg": "You havent added all components to the escrow"
+    },
+    {
+      "code": 6036,
+      "name": "ChildrenStillExist",
+      "msg": "You cannot delete this class until all children are deleted"
+    },
+    {
+      "code": 6037,
+      "name": "UnstakeTokensFirst",
+      "msg": "An item cannot be destroyed until all its staked tokens are unstaked"
+    },
+    {
+      "code": 6038,
+      "name": "AlreadyDeactivated",
+      "msg": "Already deactivated"
+    },
+    {
+      "code": 6039,
+      "name": "NotDeactivated",
+      "msg": "Escrow not deactivated"
+    },
+    {
+      "code": 6040,
+      "name": "NotEmptied",
+      "msg": "Item escrow not emptied"
+    },
+    {
+      "code": 6041,
+      "name": "GivingTooMuch",
+      "msg": "You do not need to provide this many of this component to make your recipe"
+    },
+    {
+      "code": 6042,
+      "name": "MustProvideUsageIndex",
+      "msg": "Must provide usage index"
+    },
+    {
+      "code": 6043,
+      "name": "CannotUseItemWithoutUsageOrMerkle",
+      "msg": "An item and item class must either use usage roots or merkles, if neither are present, item is unusable"
+    },
+    {
+      "code": 6044,
+      "name": "MaxUsesReached",
+      "msg": "Max uses reached"
+    },
+    {
+      "code": 6045,
+      "name": "CooldownNotOver",
+      "msg": "Cooldown not finished"
+    },
+    {
+      "code": 6046,
+      "name": "CannotUseWearable",
+      "msg": "Cannot use wearable"
+    },
+    {
+      "code": 6047,
+      "name": "UsageIndexMismatch",
+      "msg": "Usage index mismatch"
+    },
+    {
+      "code": 6048,
+      "name": "ProvingNewStateNotRequired",
+      "msg": "Proving new state not required"
+    },
+    {
+      "code": 6049,
+      "name": "MustSubmitStatesInOrder",
+      "msg": "You must submit proofs in order to revalidate the new state."
+    },
+    {
+      "code": 6050,
+      "name": "ItemActivationNotValidYet",
+      "msg": "Item activation marker not valid yet"
+    },
+    {
+      "code": 6051,
+      "name": "WarmupNotFinished",
+      "msg": "Warmup not finished"
+    },
+    {
+      "code": 6052,
+      "name": "MustBeChild",
+      "msg": "Must be a child edition"
+    },
+    {
+      "code": 6053,
+      "name": "MustUseRealScope",
+      "msg": "Must use real scope to build"
+    },
+    {
+      "code": 6054,
+      "name": "CraftClassIndexMismatch",
+      "msg": "The class index passed up does not match that on the component"
+    },
+    {
+      "code": 6055,
+      "name": "MustBeGreaterThanZero",
+      "msg": "Must use at least one of this item"
+    },
+    {
+      "code": 6056,
+      "name": "AtaShouldNotHaveDelegate",
+      "msg": "To use an ata in this contract, please remove its delegate first"
+    },
+    {
+      "code": 6057,
+      "name": "ReinitializationDetected",
+      "msg": "Reinitialization hack detected"
+    },
+    {
+      "code": 6058,
+      "name": "FailedToJoinNamespace",
+      "msg": "Failed to join namespace"
+    },
+    {
+      "code": 6059,
+      "name": "FailedToLeaveNamespace",
+      "msg": "Failed to leave namespace"
+    },
+    {
+      "code": 6060,
+      "name": "FailedToCache",
+      "msg": "Failed to cache"
+    },
+    {
+      "code": 6061,
+      "name": "FailedToUncache",
+      "msg": "Failed to uncache"
+    },
+    {
+      "code": 6062,
+      "name": "AlreadyCached",
+      "msg": "Already cached"
+    },
+    {
+      "code": 6063,
+      "name": "NotCached",
+      "msg": "Not cached"
+    },
+    {
+      "code": 6064,
+      "name": "UnauthorizedCaller",
+      "msg": "Unauthorized Caller"
+    },
+    {
+      "code": 6065,
+      "name": "MustBeCalledByStakingProgram",
+      "msg": "Must be called by staking program"
+    }
+  ],
+  "metadata": {
+    "address": "CKAcdJsyzBxHJRHgKVEsVzjX9SNcvut8t3PUD34g7ry4"
+  }
+}

--- a/rust/item-cpi/src/lib.rs
+++ b/rust/item-cpi/src/lib.rs
@@ -1,0 +1,4 @@
+
+anchor_gen::generate_cpi_crate!("item.json");
+
+anchor_lang::declare_id!("CKAcdJsyzBxHJRHgKVEsVzjX9SNcvut8t3PUD34g7ry4");

--- a/rust/item-cpi/src/lib.rs
+++ b/rust/item-cpi/src/lib.rs
@@ -1,4 +1,3 @@
-
 anchor_gen::generate_cpi_crate!("item.json");
 
 anchor_lang::declare_id!("CKAcdJsyzBxHJRHgKVEsVzjX9SNcvut8t3PUD34g7ry4");

--- a/rust/item/Cargo.toml
+++ b/rust/item/Cargo.toml
@@ -21,4 +21,4 @@ arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
-raindrops-namespace = { features = ["no-entrypoint", "cpi"], path = "../namespace"}
+raindrops-namespace-cpi = { path = "../namespace-cpi"}

--- a/rust/item/Cargo.toml
+++ b/rust/item/Cargo.toml
@@ -21,3 +21,4 @@ arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
+raindrops-namespace = { features = ["no-entrypoint", "cpi"], path = "../namespace"}

--- a/rust/item/src/lib.rs
+++ b/rust/item/src/lib.rs
@@ -26,7 +26,6 @@ use std::str::FromStr;
 pub const PREFIX: &str = "item";
 pub const MARKER: &str = "marker";
 pub const PLAYER_ID: &str = "p1exdMJcjVao65QdewkaZRUnU6VPSXhus9n2GzWfh98";
-pub const NAMESPACE_ID: &str = "nameAxQRRBnd4kLfsVoZBBXfrByZdZTkh8mULLxLyqV";
 pub const STAKING_ID: &str = "stk9HFnKhZN2PZjnn5C4wTzmeiAEgsDkbqnHkNjX1Z4";
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]

--- a/rust/item/src/lib.rs
+++ b/rust/item/src/lib.rs
@@ -21,7 +21,7 @@ use anchor_lang::{
 };
 use raindrops_namespace_cpi::typedefs::{InheritanceState, NamespaceAndIndex};
 
-anchor_lang::declare_id!("itemX1XWs9dK8T2Zca4vEEPfCAhRc7yvYFntPjTTVx6");
+anchor_lang::declare_id!("CKAcdJsyzBxHJRHgKVEsVzjX9SNcvut8t3PUD34g7ry4");
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use arrayref::array_ref;
 use std::str::FromStr;

--- a/rust/item/src/lib.rs
+++ b/rust/item/src/lib.rs
@@ -19,6 +19,8 @@ use anchor_lang::{
     },
     AnchorDeserialize, AnchorSerialize, Discriminator,
 };
+use raindrops_namespace_cpi::typedefs::{InheritanceState, NamespaceAndIndex};
+
 anchor_lang::declare_id!("itemX1XWs9dK8T2Zca4vEEPfCAhRc7yvYFntPjTTVx6");
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use arrayref::array_ref;
@@ -2797,7 +2799,7 @@ pub struct Component {
     pub inherited: InheritanceState,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Debug)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
 pub struct Permissiveness {
     pub inherited: InheritanceState,
     pub permissiveness_type: PermissivenessType,
@@ -2830,20 +2832,6 @@ pub enum ChildUpdatePropagationPermissivenessType {
     StakingPermissiveness,
     Namespaces,
     FreeBuildPermissiveness,
-}
-
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Debug)]
-pub enum InheritanceState {
-    NotInherited,
-    Inherited,
-    Overridden,
-}
-
-#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
-pub struct NamespaceAndIndex {
-    pub namespace: Pubkey,
-    pub index: Option<u64>,
-    pub inherited: InheritanceState,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]

--- a/rust/item/src/utils.rs
+++ b/rust/item/src/utils.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::{
     ChildUpdatePropagationPermissivenessType, Component, CraftUsageInfo, ErrorCode,
     InheritanceState, Inherited, Item, ItemActivationMarker, ItemActivationMarkerProofCounter,
@@ -817,7 +815,7 @@ pub fn propagate_parent_array<T: Inherited>(args: PropagateParentArrayArgs<T>) -
                 Some(c_items) => {
                     let mut new_items: Vec<T> = vec![];
                     for item in c_items {
-                        if item.get_inherited() == &InheritanceState::NotInherited {
+                        if matches!(item.get_inherited(), &InheritanceState::NotInherited) {
                             new_items.push(item.clone())
                         }
                     }
@@ -1806,9 +1804,11 @@ pub fn get_item_usage(args: GetItemUsageArgs) -> Result<ItemUsage> {
 
 // returns true if the namespace program called the item program
 pub fn is_namespace_program_caller(ixns: &AccountInfo) -> bool {
-    let current_ix = anchor_lang::solana_program::sysvar::instructions::get_instruction_relative(0, ixns).unwrap();
+    let current_ix =
+        anchor_lang::solana_program::sysvar::instructions::get_instruction_relative(0, ixns)
+            .unwrap();
 
-    if current_ix.program_id != raindrops_namespace::ID {
+    if current_ix.program_id != raindrops_namespace_cpi::ID {
         return false;
     };
 

--- a/rust/item/src/utils.rs
+++ b/rust/item/src/utils.rs
@@ -4,7 +4,7 @@ use crate::{
     ChildUpdatePropagationPermissivenessType, Component, CraftUsageInfo, ErrorCode,
     InheritanceState, Inherited, Item, ItemActivationMarker, ItemActivationMarkerProofCounter,
     ItemClass, ItemClassData, ItemClassType, ItemEscrow, ItemUsage, ItemUsageState, ItemUsageType,
-    Permissiveness, PermissivenessType, UsageInfo, NAMESPACE_ID, PREFIX,
+    Permissiveness, PermissivenessType, UsageInfo, PREFIX,
 };
 use anchor_lang::{
     error,
@@ -1808,7 +1808,7 @@ pub fn get_item_usage(args: GetItemUsageArgs) -> Result<ItemUsage> {
 pub fn is_namespace_program_caller(ixns: &AccountInfo) -> bool {
     let current_ix = anchor_lang::solana_program::sysvar::instructions::get_instruction_relative(0, ixns).unwrap();
 
-    if current_ix.program_id != Pubkey::from_str(NAMESPACE_ID).unwrap() {
+    if current_ix.program_id != raindrops_namespace::ID {
         return false;
     };
 

--- a/rust/matches-cpi/Cargo.toml
+++ b/rust/matches-cpi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "raindrops-item-cpi"
+name = "raindrops-matches-cpi"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust/matches-cpi/matches.json
+++ b/rust/matches-cpi/matches.json
@@ -1,0 +1,1188 @@
+{
+  "version": "0.1.0",
+  "name": "matches",
+  "instructions": [
+    {
+      "name": "createOrUpdateOracle",
+      "accounts": [
+        {
+          "name": "oracle",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "CreateOrUpdateOracleArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "createMatch",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "CreateMatchArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateMatch",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "winOracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "UpdateMatchArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateMatchFromOracle",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "winOracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "drainOracle",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "receiver",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "DrainOracleArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "drainMatch",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "receiver",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "leaveMatch",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "receiver",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAccountEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "destinationTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "LeaveMatchArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "disburseTokensByOracle",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAccountEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "destinationTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "winOracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "originalSender",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "DisburseTokensByOracleArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "joinMatch",
+      "accounts": [
+        {
+          "name": "matchInstance",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "tokenAccountEscrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "sourceTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "sourceItemOrPlayerPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "validationProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "JoinMatchArgs"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Match",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "winOracle",
+            "type": "publicKey"
+          },
+          {
+            "name": "winOracleCooldown",
+            "type": "u64"
+          },
+          {
+            "name": "lastOracleCheck",
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "state",
+            "type": {
+              "defined": "MatchState"
+            }
+          },
+          {
+            "name": "leaveAllowed",
+            "type": "bool"
+          },
+          {
+            "name": "minimumAllowedEntryTime",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "currentTokenTransferIndex",
+            "type": "u64"
+          },
+          {
+            "name": "tokenTypesAdded",
+            "type": "u64"
+          },
+          {
+            "name": "tokenTypesRemoved",
+            "type": "u64"
+          },
+          {
+            "name": "tokenEntryValidation",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "TokenValidation"
+                }
+              }
+            }
+          },
+          {
+            "name": "tokenEntryValidationRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "joinAllowedDuringStart",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlayerWinCallbackBitmap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "matchKey",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WinOracle",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "finalized",
+            "type": "bool"
+          },
+          {
+            "name": "tokenTransferRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "tokenTransfers",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "TokenDelta"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "CreateOrUpdateOracleArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenTransferRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "tokenTransfers",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "TokenDelta"
+                }
+              }
+            }
+          },
+          {
+            "name": "seed",
+            "type": "publicKey"
+          },
+          {
+            "name": "space",
+            "type": "u64"
+          },
+          {
+            "name": "finalized",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DrainOracleArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "seed",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMatchArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "matchState",
+            "type": {
+              "defined": "MatchState"
+            }
+          },
+          {
+            "name": "tokenEntryValidationRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "tokenEntryValidation",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "TokenValidation"
+                }
+              }
+            }
+          },
+          {
+            "name": "winOracle",
+            "type": "publicKey"
+          },
+          {
+            "name": "winOracleCooldown",
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "space",
+            "type": "u64"
+          },
+          {
+            "name": "leaveAllowed",
+            "type": "bool"
+          },
+          {
+            "name": "joinAllowedDuringStart",
+            "type": "bool"
+          },
+          {
+            "name": "minimumAllowedEntryTime",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateMatchArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "matchState",
+            "type": {
+              "defined": "MatchState"
+            }
+          },
+          {
+            "name": "tokenEntryValidationRoot",
+            "type": {
+              "option": {
+                "defined": "Root"
+              }
+            }
+          },
+          {
+            "name": "tokenEntryValidation",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "TokenValidation"
+                }
+              }
+            }
+          },
+          {
+            "name": "winOracleCooldown",
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "leaveAllowed",
+            "type": "bool"
+          },
+          {
+            "name": "joinAllowedDuringStart",
+            "type": "bool"
+          },
+          {
+            "name": "minimumAllowedEntryTime",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "JoinMatchArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "tokenEntryValidationProof",
+            "type": {
+              "option": {
+                "vec": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": "tokenEntryValidation",
+            "type": {
+              "option": {
+                "defined": "TokenValidation"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LeaveMatchArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DisburseTokensByOracleArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenDeltaProofInfo",
+            "type": {
+              "option": {
+                "defined": "TokenDeltaProofInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenDeltaProofInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenDeltaProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "tokenDelta",
+            "type": {
+              "defined": "TokenDelta"
+            }
+          },
+          {
+            "name": "totalProof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Root",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "root",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Callback",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": "publicKey"
+          },
+          {
+            "name": "code",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ValidationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "instruction",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "extraIdentifier",
+            "type": "u64"
+          },
+          {
+            "name": "tokenValidation",
+            "type": {
+              "defined": "TokenValidation"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenDelta",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from",
+            "type": "publicKey"
+          },
+          {
+            "name": "to",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "tokenTransferType",
+            "type": {
+              "defined": "TokenTransferType"
+            }
+          },
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenValidation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter",
+            "type": {
+              "defined": "Filter"
+            }
+          },
+          {
+            "name": "isBlacklist",
+            "type": "bool"
+          },
+          {
+            "name": "validation",
+            "type": {
+              "option": {
+                "defined": "Callback"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MatchState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Draft"
+          },
+          {
+            "name": "Initialized"
+          },
+          {
+            "name": "Started"
+          },
+          {
+            "name": "Finalized"
+          },
+          {
+            "name": "PaidOut"
+          },
+          {
+            "name": "Deactivated"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissivenessType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenHolder"
+          },
+          {
+            "name": "ParentTokenHolder"
+          },
+          {
+            "name": "UpdateAuthority"
+          },
+          {
+            "name": "Anybody"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InheritanceState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NotInherited"
+          },
+          {
+            "name": "Inherited"
+          },
+          {
+            "name": "Overridden"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Player"
+          },
+          {
+            "name": "Item"
+          },
+          {
+            "name": "Any"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenTransferType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "PlayerToPlayer"
+          },
+          {
+            "name": "PlayerToEntrant"
+          },
+          {
+            "name": "Normal"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Filter",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "All"
+          },
+          {
+            "name": "Namespace",
+            "fields": [
+              {
+                "name": "namespace",
+                "type": "publicKey"
+              }
+            ]
+          },
+          {
+            "name": "Parent",
+            "fields": [
+              {
+                "name": "key",
+                "type": "publicKey"
+              }
+            ]
+          },
+          {
+            "name": "Mint",
+            "fields": [
+              {
+                "name": "mint",
+                "type": "publicKey"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "IncorrectOwner",
+      "msg": "Account does not have correct owner!"
+    },
+    {
+      "code": 6001,
+      "name": "Uninitialized",
+      "msg": "Account is not initialized!"
+    },
+    {
+      "code": 6002,
+      "name": "MintMismatch",
+      "msg": "Mint Mismatch!"
+    },
+    {
+      "code": 6003,
+      "name": "TokenTransferFailed",
+      "msg": "Token transfer failed"
+    },
+    {
+      "code": 6004,
+      "name": "NumericalOverflowError",
+      "msg": "Numerical overflow error"
+    },
+    {
+      "code": 6005,
+      "name": "TokenMintToFailed",
+      "msg": "Token mint to failed"
+    },
+    {
+      "code": 6006,
+      "name": "TokenBurnFailed",
+      "msg": "TokenBurnFailed"
+    },
+    {
+      "code": 6007,
+      "name": "DerivedKeyInvalid",
+      "msg": "Derived key is invalid"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidStartingMatchState",
+      "msg": "A match can only start in draft or initialized state"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidUpdateMatchState",
+      "msg": "Match authority can only shift from Draft to Initialized or from Initialized/Started to Deactivated"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidOracleUpdate",
+      "msg": "Cannot rely on an oracle until the match has been initialized or started"
+    },
+    {
+      "code": 6011,
+      "name": "CannotDrainYet",
+      "msg": "Cannot drain a match until it is in paid out or deactivated and all token accounts have been drained"
+    },
+    {
+      "code": 6012,
+      "name": "CannotLeaveMatch",
+      "msg": "You can only leave deactivated or paid out matches, or initialized matches with leave_allowed on."
+    },
+    {
+      "code": 6013,
+      "name": "ReceiverMustBeSigner",
+      "msg": "You must be the person who joined the match to leave it in initialized or started state."
+    },
+    {
+      "code": 6014,
+      "name": "PublicKeyMismatch",
+      "msg": "Public key mismatch"
+    },
+    {
+      "code": 6015,
+      "name": "AtaShouldNotHaveDelegate",
+      "msg": "To use an ata in this contract, please remove its delegate first"
+    },
+    {
+      "code": 6016,
+      "name": "CannotEnterMatch",
+      "msg": "Can only enter matches in started or initialized state"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidProof",
+      "msg": "Invalid proof"
+    },
+    {
+      "code": 6018,
+      "name": "RootNotPresent",
+      "msg": "Root not present on object"
+    },
+    {
+      "code": 6019,
+      "name": "MustPassUpObject",
+      "msg": "If using roots, must pass up the object you are proving is a member"
+    },
+    {
+      "code": 6020,
+      "name": "NoValidValidationFound",
+      "msg": "No valid validations found"
+    },
+    {
+      "code": 6021,
+      "name": "Blacklisted",
+      "msg": "Blacklisted"
+    },
+    {
+      "code": 6022,
+      "name": "NoTokensAllowed",
+      "msg": "Tokens are explicitly not allowed in this match"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidValidation",
+      "msg": "This validation will not let in this token"
+    },
+    {
+      "code": 6024,
+      "name": "NoDeltasFound",
+      "msg": "This oracle lacks any deltas"
+    },
+    {
+      "code": 6025,
+      "name": "UsePlayerEndpoint",
+      "msg": "Please use the player-specific endpoint for token transfers from a player"
+    },
+    {
+      "code": 6026,
+      "name": "FromDoesNotMatch",
+      "msg": "The original_sender argument does not match the from on the token delta"
+    },
+    {
+      "code": 6027,
+      "name": "CannotDeltaMoreThanAmountPresent",
+      "msg": "Cannot give away more than is present in the token account"
+    },
+    {
+      "code": 6028,
+      "name": "DeltaMintDoesNotMatch",
+      "msg": "Delta mint must match provided token mint account"
+    },
+    {
+      "code": 6029,
+      "name": "DestinationMismatch",
+      "msg": "The given destination token account does not match the delta to field"
+    },
+    {
+      "code": 6030,
+      "name": "MatchMustBeInFinalized",
+      "msg": "Match must be in finalized state to diburse"
+    },
+    {
+      "code": 6031,
+      "name": "AtaDelegateMismatch",
+      "msg": "ATA delegate mismatch"
+    },
+    {
+      "code": 6032,
+      "name": "OracleAlreadyFinalized",
+      "msg": "Oracle already finalized"
+    },
+    {
+      "code": 6033,
+      "name": "OracleCooldownNotPassed",
+      "msg": "Oracle cooldown not over"
+    },
+    {
+      "code": 6034,
+      "name": "MatchMustBeDrained",
+      "msg": "Match must be drained first"
+    },
+    {
+      "code": 6035,
+      "name": "NoParentPresent",
+      "msg": "No parent present"
+    },
+    {
+      "code": 6036,
+      "name": "ReinitializationDetected",
+      "msg": "Reinitialization hack detected"
+    }
+  ]
+}

--- a/rust/matches-cpi/src/lib.rs
+++ b/rust/matches-cpi/src/lib.rs
@@ -1,0 +1,3 @@
+anchor_gen::generate_cpi_crate!("matches.json");
+
+anchor_lang::declare_id!("7LyB5WFdVLBQ1zZ21djZRjSr6WzBSfPvNBsJxnhUTCQK");

--- a/rust/matches/Cargo.toml
+++ b/rust/matches/Cargo.toml
@@ -20,5 +20,4 @@ anchor-spl = "0.24.2"
 arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
-metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
-raindrops-namespace = { features = [ "no-entrypoint" ], path = "../namespace" }
+raindrops-namespace-cpi = { path = "../namespace-cpi" }

--- a/rust/matches/src/lib.rs
+++ b/rust/matches/src/lib.rs
@@ -8,7 +8,7 @@ use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize, Discriminator}
 use anchor_spl::token::{Mint, TokenAccount};
 use arrayref::array_ref;
 use raindrops_namespace_cpi::typedefs::NamespaceAndIndex;
-anchor_lang::declare_id!("mtchsiT6WoLQ62fwCoiHMCfXJzogtfru4ovY8tXKrjJ");
+anchor_lang::declare_id!("7LyB5WFdVLBQ1zZ21djZRjSr6WzBSfPvNBsJxnhUTCQK");
 pub const PREFIX: &str = "matches";
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]

--- a/rust/matches/src/lib.rs
+++ b/rust/matches/src/lib.rs
@@ -1,28 +1,13 @@
 pub mod utils;
 
 use crate::utils::{
-    assert_derivation, assert_initialized, assert_is_ata, assert_owned_by, close_token_account,
-    create_or_allocate_account_raw, get_mask_and_index_for_seq, is_part_of_namespace,
-    is_valid_validation, spl_token_burn, spl_token_mint_to, spl_token_transfer, verify,
-    TokenBurnParams, TokenTransferParams,
+    assert_is_ata, close_token_account, is_valid_validation, spl_token_burn, spl_token_transfer,
+    verify, TokenBurnParams, TokenTransferParams,
 };
-use anchor_lang::{
-    prelude::*,
-    solana_program::{
-        program::{invoke, invoke_signed},
-        program_option::COption,
-        program_pack::Pack,
-        system_instruction, system_program,
-    },
-    AnchorDeserialize, AnchorSerialize, Discriminator,
-};
+use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize, Discriminator};
 use anchor_spl::token::{Mint, TokenAccount};
 use arrayref::array_ref;
-use metaplex_token_metadata::instruction::{
-    create_master_edition, create_metadata_accounts,
-    mint_new_edition_from_master_edition_via_token, update_metadata_accounts,
-};
-use spl_token::instruction::{initialize_account2, mint_to};
+use raindrops_namespace_cpi::typedefs::NamespaceAndIndex;
 anchor_lang::declare_id!("mtchsiT6WoLQ62fwCoiHMCfXJzogtfru4ovY8tXKrjJ");
 pub const PREFIX: &str = "matches";
 
@@ -810,13 +795,6 @@ pub struct ValidationArgs {
     instruction: [u8; 8],
     extra_identifier: u64,
     token_validation: TokenValidation,
-}
-
-#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
-pub struct NamespaceAndIndex {
-    namespace: Pubkey,
-    indexed: bool,
-    inherited: InheritanceState,
 }
 
 pub const MIN_MATCH_SIZE: usize = 8 + // discriminator

--- a/rust/namespace-cpi/Cargo.toml
+++ b/rust/namespace-cpi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "raindrops-item-cpi"
+name = "raindrops-namespace-cpi"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust/namespace-cpi/namespace.json
+++ b/rust/namespace-cpi/namespace.json
@@ -1,0 +1,1122 @@
+{
+  "version": "0.1.0",
+  "name": "namespace",
+  "instructions": [
+    {
+      "name": "initializeNamespace",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "metadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEdition",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "InitializeNamespaceArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateNamespace",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "UpdateNamespaceArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "cacheArtifact",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "index",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "CacheArtifactArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "uncacheArtifact",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "index",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "UncacheArtifactArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "createNamespaceGatekeeper",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceGatekeeper",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "addToNamespaceGatekeeper",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceGatekeeper",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "artifactFilter",
+          "type": {
+            "defined": "ArtifactFilter"
+          }
+        }
+      ]
+    },
+    {
+      "name": "removeFromNamespaceGatekeeper",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceGatekeeper",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "artifactFilter",
+          "type": {
+            "defined": "ArtifactFilter"
+          }
+        }
+      ]
+    },
+    {
+      "name": "leaveNamespace",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceGatekeeper",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "joinNamespace",
+      "accounts": [
+        {
+          "name": "namespace",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "namespaceGatekeeper",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenHolder",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "itemValidation",
+      "accounts": [
+        {
+          "name": "itemClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "item",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itemAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ValidationArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "matchValidation",
+      "accounts": [
+        {
+          "name": "sourceItemOrPlayerPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MatchValidationArgs"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "NamespaceGatekeeper",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "namespace",
+            "type": "publicKey"
+          },
+          {
+            "name": "artifactFilters",
+            "type": {
+              "vec": {
+                "defined": "ArtifactFilter"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Namespace",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "metadata",
+            "type": "publicKey"
+          },
+          {
+            "name": "masterEdition",
+            "type": "publicKey"
+          },
+          {
+            "name": "uuid",
+            "type": "string"
+          },
+          {
+            "name": "prettyName",
+            "type": "string"
+          },
+          {
+            "name": "artifactsAdded",
+            "type": "u64"
+          },
+          {
+            "name": "maxPages",
+            "type": "u64"
+          },
+          {
+            "name": "fullPages",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "artifactsCached",
+            "type": "u64"
+          },
+          {
+            "name": "permissivenessSettings",
+            "type": {
+              "defined": "PermissivenessSettings"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "whitelistedStakingMints",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "gatekeeper",
+            "type": {
+              "option": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NamespaceIndex",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespace",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "page",
+            "type": "u64"
+          },
+          {
+            "name": "caches",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "InitializeNamespaceArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "desiredNamespaceArraySize",
+            "type": "u64"
+          },
+          {
+            "name": "uuid",
+            "type": "string"
+          },
+          {
+            "name": "prettyName",
+            "type": "string"
+          },
+          {
+            "name": "permissivenessSettings",
+            "type": {
+              "defined": "PermissivenessSettings"
+            }
+          },
+          {
+            "name": "whitelistedStakingMints",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateNamespaceArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "prettyName",
+            "type": {
+              "option": "string"
+            }
+          },
+          {
+            "name": "permissivenessSettings",
+            "type": {
+              "option": {
+                "defined": "PermissivenessSettings"
+              }
+            }
+          },
+          {
+            "name": "whitelistedStakingMints",
+            "type": {
+              "option": {
+                "vec": "publicKey"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CacheArtifactArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "page",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UncacheArtifactArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "page",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ArtifactFilter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter",
+            "type": {
+              "defined": "Filter"
+            }
+          },
+          {
+            "name": "tokenType",
+            "type": {
+              "defined": "ArtifactType"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissivenessSettings",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespacePermissiveness",
+            "type": {
+              "defined": "Permissiveness"
+            }
+          },
+          {
+            "name": "itemPermissiveness",
+            "type": {
+              "defined": "Permissiveness"
+            }
+          },
+          {
+            "name": "playerPermissiveness",
+            "type": {
+              "defined": "Permissiveness"
+            }
+          },
+          {
+            "name": "matchPermissiveness",
+            "type": {
+              "defined": "Permissiveness"
+            }
+          },
+          {
+            "name": "missionPermissiveness",
+            "type": {
+              "defined": "Permissiveness"
+            }
+          },
+          {
+            "name": "cachePermissiveness",
+            "type": {
+              "defined": "Permissiveness"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NamespaceAndIndex",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespace",
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ValidationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "extraIdentifier",
+            "type": "u64"
+          },
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "itemClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "usagePermissivenessToUse",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "usageIndex",
+            "type": "u16"
+          },
+          {
+            "name": "usageInfo",
+            "type": {
+              "option": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Callback",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": "publicKey"
+          },
+          {
+            "name": "code",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenValidation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter",
+            "type": {
+              "defined": "TokenValidationFilter"
+            }
+          },
+          {
+            "name": "isBlacklist",
+            "type": "bool"
+          },
+          {
+            "name": "validation",
+            "type": {
+              "option": {
+                "defined": "Callback"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MatchValidationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "extraIdentifier",
+            "type": "u64"
+          },
+          {
+            "name": "tokenValidation",
+            "type": {
+              "defined": "TokenValidation"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permissiveness",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "All"
+          },
+          {
+            "name": "Whitelist"
+          },
+          {
+            "name": "Blacklist"
+          },
+          {
+            "name": "Namespace"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ArtifactType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Player"
+          },
+          {
+            "name": "Item"
+          },
+          {
+            "name": "Mission"
+          },
+          {
+            "name": "Namespace"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Filter",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Namespace",
+            "fields": [
+              {
+                "name": "namespaces",
+                "type": {
+                  "vec": "publicKey"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Category",
+            "fields": [
+              {
+                "name": "namespace",
+                "type": "publicKey"
+              },
+              {
+                "name": "category",
+                "type": {
+                  "option": {
+                    "vec": "string"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "Key",
+            "fields": [
+              {
+                "name": "key",
+                "type": "publicKey"
+              },
+              {
+                "name": "mint",
+                "type": "publicKey"
+              },
+              {
+                "name": "metadata",
+                "type": "publicKey"
+              },
+              {
+                "name": "edition",
+                "type": {
+                  "option": "publicKey"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "InheritanceState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NotInherited"
+          },
+          {
+            "name": "Inherited"
+          },
+          {
+            "name": "Overridden"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenValidationFilter",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "All"
+          },
+          {
+            "name": "Namespace",
+            "fields": [
+              {
+                "name": "namespace",
+                "type": "publicKey"
+              }
+            ]
+          },
+          {
+            "name": "Parent",
+            "fields": [
+              {
+                "name": "key",
+                "type": "publicKey"
+              }
+            ]
+          },
+          {
+            "name": "Mint",
+            "fields": [
+              {
+                "name": "mint",
+                "type": "publicKey"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "IncorrectOwner",
+      "msg": "Account does not have correct owner!"
+    },
+    {
+      "code": 6001,
+      "name": "Uninitialized",
+      "msg": "Account is not initialized!"
+    },
+    {
+      "code": 6002,
+      "name": "MintMismatch",
+      "msg": "Mint Mismatch!"
+    },
+    {
+      "code": 6003,
+      "name": "TokenTransferFailed",
+      "msg": "Token transfer failed"
+    },
+    {
+      "code": 6004,
+      "name": "NumericalOverflowError",
+      "msg": "Numerical overflow error"
+    },
+    {
+      "code": 6005,
+      "name": "TokenMintToFailed",
+      "msg": "Token mint to failed"
+    },
+    {
+      "code": 6006,
+      "name": "TokenBurnFailed",
+      "msg": "TokenBurnFailed"
+    },
+    {
+      "code": 6007,
+      "name": "DerivedKeyInvalid",
+      "msg": "Derived key is invalid"
+    },
+    {
+      "code": 6008,
+      "name": "UUIDTooLong",
+      "msg": "UUID too long, 6 char max"
+    },
+    {
+      "code": 6009,
+      "name": "PrettyNameTooLong",
+      "msg": "Pretty name too long, 32 char max"
+    },
+    {
+      "code": 6010,
+      "name": "WhitelistStakeListTooLong",
+      "msg": "Whitelist stake list too long, 5 max"
+    },
+    {
+      "code": 6011,
+      "name": "MetadataDoesntExist",
+      "msg": "Metadata doesnt exist"
+    },
+    {
+      "code": 6012,
+      "name": "EditionDoesntExist",
+      "msg": "Edition doesnt exist"
+    },
+    {
+      "code": 6013,
+      "name": "PreviousIndexNotFull",
+      "msg": "The previous index is not full yet, so you cannot make a new one"
+    },
+    {
+      "code": 6014,
+      "name": "IndexFull",
+      "msg": "Index is full"
+    },
+    {
+      "code": 6015,
+      "name": "CanOnlyCacheValidRaindropsObjects",
+      "msg": "Can only cache valid raindrops artifacts (players, items, matches)"
+    },
+    {
+      "code": 6016,
+      "name": "ArtifactLacksNamespace",
+      "msg": "Artifact lacks namespace!"
+    },
+    {
+      "code": 6017,
+      "name": "ArtifactNotPartOfNamespace",
+      "msg": "Artifact not part of namespace!"
+    },
+    {
+      "code": 6018,
+      "name": "CannotJoinNamespace",
+      "msg": "You do not have permissions to join this namespace"
+    },
+    {
+      "code": 6019,
+      "name": "ArtifactStillCached",
+      "msg": "You cannot remove an artifact from a namespace while it is still cached there. Uncache it first."
+    },
+    {
+      "code": 6020,
+      "name": "CacheFull",
+      "msg": "Artifact Cache full"
+    }
+  ]
+}

--- a/rust/namespace-cpi/src/lib.rs
+++ b/rust/namespace-cpi/src/lib.rs
@@ -1,0 +1,3 @@
+anchor_gen::generate_cpi_crate!("namespace.json");
+
+anchor_lang::declare_id!("AguQatwNFEaZSFUHsTj5fcU3LdsNFQLrYSHQjZ4erC8X");

--- a/rust/namespace/Cargo.toml
+++ b/rust/namespace/Cargo.toml
@@ -21,4 +21,4 @@ arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
-item-cpi = { features = ["no-entrypoint", "cpi"], path = "../item-cpi"}
+raindrops-item-cpi = { path = "../item-cpi"}

--- a/rust/namespace/Cargo.toml
+++ b/rust/namespace/Cargo.toml
@@ -21,4 +21,6 @@ arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
-raindrops-item-cpi = { path = "../item-cpi"}
+raindrops-item = { features = ["no-entrypoint", "cpi"], path = "../item"}
+raindrops-matches = { features = ["no-entrypoint", "cpi"], path = "../matches"}
+raindrops-player = { features = ["no-entrypoint", "cpi"], path = "../player"}

--- a/rust/namespace/Cargo.toml
+++ b/rust/namespace/Cargo.toml
@@ -21,4 +21,4 @@ arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
-raindrops-item = { features = [ "no-entrypoint", "cpi"], path = "../item" }
+item-cpi = { features = ["no-entrypoint", "cpi"], path = "../item-cpi"}

--- a/rust/namespace/src/lib.rs
+++ b/rust/namespace/src/lib.rs
@@ -6,18 +6,17 @@ use crate::utils::{
 };
 use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize};
 use anchor_spl::token::{Mint, Token, TokenAccount};
-use item_cpi::{
+use raindrops_item_cpi::{
     cpi::{
         accounts::{
             ItemClassCacheNamespace, ItemClassJoinNamespace, ItemClassLeaveNamespace,
-            ItemClassUncacheNamespace, CreateItemClass,
+            ItemClassUncacheNamespace,
         },
         item_class_cache_namespace, item_class_join_namespace, item_class_leave_namespace,
-        item_class_uncache_namespace, create_item_class
+        item_class_uncache_namespace,
     },
     program::Item,
 };
-use item_cpi::typedefs::CreateItemClassArgs;
 use std::str::FromStr;
 anchor_lang::declare_id!("nameAxQRRBnd4kLfsVoZBBXfrByZdZTkh8mULLxLyqV");
 pub const PLAYER_ID: &str = "p1exdMJcjVao65QdewkaZRUnU6VPSXhus9n2GzWfh98";

--- a/rust/namespace/src/lib.rs
+++ b/rust/namespace/src/lib.rs
@@ -6,22 +6,18 @@ use crate::utils::{
 };
 use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize};
 use anchor_spl::token::{Mint, Token, TokenAccount};
-use raindrops_item_cpi::{
+use raindrops_item::{
     cpi::{
         accounts::{
             ItemClassCacheNamespace, ItemClassJoinNamespace, ItemClassLeaveNamespace,
-            ItemClassUncacheNamespace,
+            ItemClassUnCacheNamespace,
         },
         item_class_cache_namespace, item_class_join_namespace, item_class_leave_namespace,
         item_class_uncache_namespace,
     },
     program::Item,
 };
-use std::str::FromStr;
-anchor_lang::declare_id!("nameAxQRRBnd4kLfsVoZBBXfrByZdZTkh8mULLxLyqV");
-pub const PLAYER_ID: &str = "p1exdMJcjVao65QdewkaZRUnU6VPSXhus9n2GzWfh98";
-pub const MATCH_ID: &str = "mtchsiT6WoLQ62fwCoiHMCfXJzogtfru4ovY8tXKrjJ";
-pub const ITEM_ID: &str = "itemX1XWs9dK8T2Zca4vEEPfCAhRc7yvYFntPjTTVx6";
+anchor_lang::declare_id!("AguQatwNFEaZSFUHsTj5fcU3LdsNFQLrYSHQjZ4erC8X");
 
 pub const PREFIX: &str = "namespace";
 const GATEKEEPER: &str = "gatekeeper";
@@ -188,9 +184,9 @@ pub mod namespace {
             return Err(error!(ErrorCode::ArtifactLacksNamespace));
         }
 
-        if artifact.owner != &Pubkey::from_str(PLAYER_ID).unwrap()
-            && artifact.owner != &Pubkey::from_str(MATCH_ID).unwrap()
-            && artifact.owner != &Pubkey::from_str(ITEM_ID).unwrap()
+        if artifact.owner.eq(&raindrops_player::ID)
+            && artifact.owner.eq(&raindrops_matches::ID) 
+            && artifact.owner.eq(&raindrops_item::ID)
             && artifact.owner != &id()
         {
             return Err(error!(ErrorCode::CanOnlyCacheValidRaindropsObjects));
@@ -277,7 +273,7 @@ pub mod namespace {
             .ok_or(ErrorCode::NumericalOverflowError)?;
 
         // remove cache information from item
-        let accounts = ItemClassUncacheNamespace {
+        let accounts = ItemClassUnCacheNamespace {
             item_class: ctx.accounts.artifact.to_account_info(),
             namespace: ctx.accounts.namespace.to_account_info(),
             instructions: ctx.accounts.instructions.to_account_info(),

--- a/rust/namespace/src/lib.rs
+++ b/rust/namespace/src/lib.rs
@@ -10,13 +10,14 @@ use item_cpi::{
     cpi::{
         accounts::{
             ItemClassCacheNamespace, ItemClassJoinNamespace, ItemClassLeaveNamespace,
-            ItemClassUncacheNamespace,
+            ItemClassUncacheNamespace, CreateItemClass,
         },
         item_class_cache_namespace, item_class_join_namespace, item_class_leave_namespace,
-        item_class_uncache_namespace,
+        item_class_uncache_namespace, create_item_class
     },
     program::Item,
 };
+use item_cpi::typedefs::CreateItemClassArgs;
 use std::str::FromStr;
 anchor_lang::declare_id!("nameAxQRRBnd4kLfsVoZBBXfrByZdZTkh8mULLxLyqV");
 pub const PLAYER_ID: &str = "p1exdMJcjVao65QdewkaZRUnU6VPSXhus9n2GzWfh98";

--- a/rust/namespace/src/lib.rs
+++ b/rust/namespace/src/lib.rs
@@ -6,11 +6,11 @@ use crate::utils::{
 };
 use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize};
 use anchor_spl::token::{Mint, Token, TokenAccount};
-use raindrops_item::{
+use item_cpi::{
     cpi::{
         accounts::{
             ItemClassCacheNamespace, ItemClassJoinNamespace, ItemClassLeaveNamespace,
-            ItemClassUnCacheNamespace,
+            ItemClassUncacheNamespace,
         },
         item_class_cache_namespace, item_class_join_namespace, item_class_leave_namespace,
         item_class_uncache_namespace,
@@ -277,7 +277,7 @@ pub mod namespace {
             .ok_or(ErrorCode::NumericalOverflowError)?;
 
         // remove cache information from item
-        let accounts = ItemClassUnCacheNamespace {
+        let accounts = ItemClassUncacheNamespace {
             item_class: ctx.accounts.artifact.to_account_info(),
             namespace: ctx.accounts.namespace.to_account_info(),
             instructions: ctx.accounts.instructions.to_account_info(),

--- a/rust/namespace/src/utils.rs
+++ b/rust/namespace/src/utils.rs
@@ -14,8 +14,8 @@ use anchor_lang::{
     Key, ToAccountInfo,
 };
 use arrayref::array_ref;
-use raindrops_item_cpi::ItemClass;
-use std::{convert::TryInto, str::FromStr};
+use raindrops_item::ItemClass;
+use std::convert::TryInto;
 
 pub fn assert_initialized<T: Pack + IsInitialized>(account_info: &AccountInfo) -> Result<T> {
     let account: T = T::unpack_unchecked(&account_info.data.borrow())?;
@@ -390,7 +390,7 @@ pub fn assert_can_add_to_namespace<'a>(
     namespace: &Account<'a, Namespace>,
     namespace_gatekeeper: &Account<'a, NamespaceGatekeeper>,
 ) -> Result<()> {
-    let art_namespaces = if artifact.owner == &Pubkey::from_str(crate::PLAYER_ID).unwrap() {
+    let art_namespaces = if artifact.owner.eq(&raindrops_player::ID) {
         msg!("player_id match");
         check_permissiveness_against_holder(
             artifact,
@@ -398,7 +398,7 @@ pub fn assert_can_add_to_namespace<'a>(
             namespace_gatekeeper,
             &namespace.permissiveness_settings.player_permissiveness,
         )?
-    } else if artifact.owner == &Pubkey::from_str(crate::ITEM_ID).unwrap() {
+    } else if artifact.owner.eq(&raindrops_item::ID) {
         msg!("item_id match");
         check_permissiveness_against_holder(
             artifact,
@@ -406,7 +406,7 @@ pub fn assert_can_add_to_namespace<'a>(
             namespace_gatekeeper,
             &namespace.permissiveness_settings.item_permissiveness,
         )?
-    } else if artifact.owner == &Pubkey::from_str(crate::MATCH_ID).unwrap() {
+    } else if artifact.owner.eq(&raindrops_matches::ID) {
         msg!("match_id match");
         check_permissiveness_against_holder(
             artifact,
@@ -414,7 +414,7 @@ pub fn assert_can_add_to_namespace<'a>(
             namespace_gatekeeper,
             &namespace.permissiveness_settings.match_permissiveness,
         )?
-    } else if artifact.owner == &crate::id() {
+    } else if artifact.owner.eq(&crate::id()) {
         msg!("namespace_id match");
         check_permissiveness_against_holder(
             artifact,

--- a/rust/namespace/src/utils.rs
+++ b/rust/namespace/src/utils.rs
@@ -14,7 +14,7 @@ use anchor_lang::{
     Key, ToAccountInfo,
 };
 use arrayref::array_ref;
-use raindrops_item::ItemClass;
+use item_cpi::ItemClass;
 use std::{convert::TryInto, str::FromStr};
 
 pub fn assert_initialized<T: Pack + IsInitialized>(account_info: &AccountInfo) -> Result<T> {

--- a/rust/namespace/src/utils.rs
+++ b/rust/namespace/src/utils.rs
@@ -14,7 +14,7 @@ use anchor_lang::{
     Key, ToAccountInfo,
 };
 use arrayref::array_ref;
-use item_cpi::ItemClass;
+use raindrops_item_cpi::ItemClass;
 use std::{convert::TryInto, str::FromStr};
 
 pub fn assert_initialized<T: Pack + IsInitialized>(account_info: &AccountInfo) -> Result<T> {

--- a/rust/player-cpi/Cargo.toml
+++ b/rust/player-cpi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "raindrops-item-cpi"
+name = "raindrops-player-cpi"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust/player-cpi/player.json
+++ b/rust/player-cpi/player.json
@@ -1,0 +1,589 @@
+{
+  "version": "0.1.0",
+  "name": "player",
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "PlayerClass",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "parent",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "mint",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "metadata",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "edition",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "startingStatsUri",
+            "type": {
+              "option": {
+                "defined": "StatsUri"
+              }
+            }
+          },
+          {
+            "name": "defaultCategory",
+            "type": {
+              "option": {
+                "defined": "PlayerCategory"
+              }
+            }
+          },
+          {
+            "name": "childrenMustBeEditions",
+            "type": "bool"
+          },
+          {
+            "name": "builderMustBeHolder",
+            "type": "bool"
+          },
+          {
+            "name": "updatePermissiveness",
+            "type": {
+              "vec": {
+                "defined": "Permissiveness"
+              }
+            }
+          },
+          {
+            "name": "childUpdatePropagationPermissiveness",
+            "type": {
+              "vec": {
+                "defined": "ChildUpdatePropagationPermissiveness"
+              }
+            }
+          },
+          {
+            "name": "bodyParts",
+            "type": {
+              "vec": {
+                "defined": "BodyPart"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Player",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "type": "u8"
+          },
+          {
+            "name": "parent",
+            "type": "publicKey"
+          },
+          {
+            "name": "mint",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "metadata",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "edition",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "statsUri",
+            "type": {
+              "option": {
+                "defined": "StatsUri"
+              }
+            }
+          },
+          {
+            "name": "category",
+            "type": {
+              "option": {
+                "defined": "PlayerCategory"
+              }
+            }
+          },
+          {
+            "name": "updatePermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "equippedItems",
+            "type": {
+              "vec": {
+                "defined": "EquippedItem"
+              }
+            }
+          },
+          {
+            "name": "activatedItems",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "basicStats",
+            "type": {
+              "vec": {
+                "defined": "BasicStat"
+              }
+            }
+          },
+          {
+            "name": "bodyParts",
+            "type": {
+              "vec": {
+                "defined": "BodyPart"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "Root",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          },
+          {
+            "name": "root",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EquippedItem",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "item",
+            "type": "publicKey"
+          },
+          {
+            "name": "itemClass",
+            "type": "publicKey"
+          },
+          {
+            "name": "bodyPart",
+            "type": "string"
+          },
+          {
+            "name": "category",
+            "type": "string"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlayerCategory",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "category",
+            "type": "string"
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StatsUri",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "statsUri",
+            "type": "string"
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BodyPart",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bodyPart",
+            "type": "string"
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BasicStat",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "statType",
+            "type": {
+              "defined": "BasicStatType"
+            }
+          },
+          {
+            "name": "inherited",
+            "type": {
+              "defined": "InheritanceState"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permissiveness",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenHolder",
+            "fields": [
+              {
+                "name": "inherited",
+                "type": {
+                  "defined": "InheritanceState"
+                }
+              }
+            ]
+          },
+          {
+            "name": "PlayerParentTokenHolder",
+            "fields": [
+              {
+                "name": "inherited",
+                "type": {
+                  "defined": "InheritanceState"
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateAuthority",
+            "fields": [
+              {
+                "name": "inherited",
+                "type": {
+                  "defined": "InheritanceState"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Anybody",
+            "fields": [
+              {
+                "name": "inherited",
+                "type": {
+                  "defined": "InheritanceState"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChildUpdatePropagationPermissiveness",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Usages"
+          },
+          {
+            "name": "Components"
+          },
+          {
+            "name": "UpdatePermissiveness"
+          },
+          {
+            "name": "BuildPermissiveness"
+          },
+          {
+            "name": "ChildUpdatePropagationPermissiveness"
+          },
+          {
+            "name": "ChildrenMustBeEditionsPermissiveness"
+          },
+          {
+            "name": "BuilderMustBeHolderPermissiveness"
+          },
+          {
+            "name": "StakingPermissiveness"
+          },
+          {
+            "name": "Namespaces"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BasicStatType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Enum",
+            "fields": [
+              {
+                "name": "initial",
+                "type": "u8"
+              },
+              {
+                "name": "values",
+                "type": {
+                  "vec": {
+                    "defined": "Threshold"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "Integer",
+            "fields": [
+              {
+                "name": "min",
+                "type": {
+                  "option": "i64"
+                }
+              },
+              {
+                "name": "max",
+                "type": {
+                  "option": "i64"
+                }
+              },
+              {
+                "name": "initial",
+                "type": "i64"
+              },
+              {
+                "name": "staking_amount_scaler",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "staking_duration_scaler",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "padding",
+                "type": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              },
+              {
+                "name": "padding2",
+                "type": {
+                  "array": [
+                    "u8",
+                    8
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "Bool",
+            "fields": [
+              {
+                "name": "initial",
+                "type": "bool"
+              },
+              {
+                "name": "staking_flip",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "padding",
+                "type": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              },
+              {
+                "name": "padding2",
+                "type": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              },
+              {
+                "name": "padding3",
+                "type": {
+                  "array": [
+                    "u8",
+                    8
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "String",
+            "fields": [
+              {
+                "name": "initial",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "IncorrectOwner",
+      "msg": "Account does not have correct owner!"
+    },
+    {
+      "code": 6001,
+      "name": "Uninitialized",
+      "msg": "Account is not initialized!"
+    },
+    {
+      "code": 6002,
+      "name": "MintMismatch",
+      "msg": "Mint Mismatch!"
+    },
+    {
+      "code": 6003,
+      "name": "TokenTransferFailed",
+      "msg": "Token transfer failed"
+    },
+    {
+      "code": 6004,
+      "name": "NumericalOverflowError",
+      "msg": "Numerical overflow error"
+    },
+    {
+      "code": 6005,
+      "name": "TokenMintToFailed",
+      "msg": "Token mint to failed"
+    },
+    {
+      "code": 6006,
+      "name": "TokenBurnFailed",
+      "msg": "TokenBurnFailed"
+    },
+    {
+      "code": 6007,
+      "name": "DerivedKeyInvalid",
+      "msg": "Derived key is invalid"
+    }
+  ]
+}

--- a/rust/player-cpi/src/lib.rs
+++ b/rust/player-cpi/src/lib.rs
@@ -1,0 +1,3 @@
+anchor_gen::generate_cpi_crate!("player.json");
+
+anchor_lang::declare_id!("7LyB5WFdVLBQ1zZ21djZRjSr6WzBSfPvNBsJxnhUTCQK");

--- a/rust/player/Cargo.toml
+++ b/rust/player/Cargo.toml
@@ -21,4 +21,4 @@ arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 metaplex-token-metadata = { version="0.0.1", features = [ "no-entrypoint" ] }
-raindrops-namespace = { features = [ "no-entrypoint" ], path = "../namespace" }
+raindrops-namespace-cpi = { path = "../namespace-cpi" }

--- a/rust/player/src/lib.rs
+++ b/rust/player/src/lib.rs
@@ -1,37 +1,14 @@
 pub mod utils;
 
-use crate::utils::{
-    assert_derivation, assert_initialized, assert_owned_by, create_or_allocate_account_raw,
-    get_mask_and_index_for_seq, spl_token_burn, spl_token_mint_to, spl_token_transfer,
-    TokenBurnParams, TokenTransferParams,
-};
-use anchor_lang::{
-    prelude::*,
-    solana_program::{
-        program::{invoke, invoke_signed},
-        program_option::COption,
-        program_pack::Pack,
-        system_instruction, system_program,
-    },
-    AnchorDeserialize, AnchorSerialize,
-};
-use anchor_spl::token::{Mint, TokenAccount};
-use metaplex_token_metadata::instruction::{
-    create_master_edition, create_metadata_accounts,
-    mint_new_edition_from_master_edition_via_token, update_metadata_accounts,
-};
-use spl_token::{
-    instruction::{initialize_account2, mint_to},
-    state::Account,
-};
+use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize};
+
+use raindrops_namespace_cpi::{InheritanceState, NamespaceAndIndex};
 
 anchor_lang::declare_id!("p1exdMJcjVao65QdewkaZRUnU6VPSXhus9n2GzWfh98");
 
 pub const PREFIX: &str = "player";
 #[program]
-pub mod player {
-    use super::*;
-}
+pub mod player {}
 
 pub const EQUIPPED_ITEM_SIZE: usize = 32 + //item 
 32 + // item
@@ -78,13 +55,6 @@ pub enum ChildUpdatePropagationPermissiveness {
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
-pub enum InheritanceState {
-    NotInherited,
-    Inherited,
-    Overriden,
-}
-
-#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct PlayerCategory {
     category: String,
     inherited: InheritanceState,
@@ -99,13 +69,6 @@ pub struct StatsUri {
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct BodyPart {
     body_part: String,
-    inherited: InheritanceState,
-}
-
-#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
-pub struct NamespaceAndIndex {
-    namespace: Pubkey,
-    indexed: bool,
     inherited: InheritanceState,
 }
 

--- a/rust/staking-cpi/Cargo.toml
+++ b/rust/staking-cpi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "raindrops-item-cpi"
+name = "staking-cpi"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust/staking-cpi/src/lib.rs
+++ b/rust/staking-cpi/src/lib.rs
@@ -1,0 +1,3 @@
+anchor_gen::generate_cpi_crate!("staking.json");
+
+anchor_lang::declare_id!("DQYqo3vkeJPZyyhK84iUz9eozu1WASELK1XH2Sowa8qm");

--- a/rust/staking-cpi/staking.json
+++ b/rust/staking-cpi/staking.json
@@ -1,0 +1,833 @@
+{
+  "version": "0.1.0",
+  "name": "staking",
+  "instructions": [
+    {
+      "name": "beginArtifactStakeWarmup",
+      "accounts": [
+        {
+          "name": "artifactClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingCounter",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "stakingAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakingMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakingTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "namespace",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "BeginArtifactStakeWarmupArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "endArtifactStakeWarmup",
+      "accounts": [
+        {
+          "name": "artifactClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingCounter",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactMintStakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "stakingMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "itemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "playerProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "EndArtifactStakeWarmupArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "beginArtifactStakeCooldown",
+      "accounts": [
+        {
+          "name": "artifactClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingCounter",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactMintStakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "stakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "stakingMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "itemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "playerProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "BeginArtifactStakeCooldownArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "endArtifactStakeCooldown",
+      "accounts": [
+        {
+          "name": "artifactClass",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifact",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "artifactIntermediaryStakingCounter",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "stakingAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "stakingMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "EndArtifactStakeCooldownArgs"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "StakingCounter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "eventStart",
+            "type": "i64"
+          },
+          {
+            "name": "eventType",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ArtifactClass",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "parent",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "mint",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "metadata",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "edition",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "existingChildren",
+            "type": "u64"
+          },
+          {
+            "name": "data",
+            "type": {
+              "defined": "ArtifactClassData"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Artifact",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "namespaces",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "NamespaceAndIndex"
+                }
+              }
+            }
+          },
+          {
+            "name": "parent",
+            "type": "publicKey"
+          },
+          {
+            "name": "mint",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "metadata",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "edition",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "tokensStaked",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "BeginArtifactStakeWarmupArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "stakingIndex",
+            "type": "u64"
+          },
+          {
+            "name": "artifactClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "artifactMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "stakingAmount",
+            "type": "u64"
+          },
+          {
+            "name": "stakingPermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EndArtifactStakeWarmupArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "stakingIndex",
+            "type": "u64"
+          },
+          {
+            "name": "artifactClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "artifactMint",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BeginArtifactStakeCooldownArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "parentClassIndex",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "stakingIndex",
+            "type": "u64"
+          },
+          {
+            "name": "artifactClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "artifactMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "stakingPermissivenessToUse",
+            "type": {
+              "option": {
+                "defined": "PermissivenessType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EndArtifactStakeCooldownArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "classIndex",
+            "type": "u64"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "stakingIndex",
+            "type": "u64"
+          },
+          {
+            "name": "artifactClassMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "artifactMint",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ArtifactClassData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "childrenMustBeEditions",
+            "type": {
+              "option": {
+                "defined": "Boolean"
+              }
+            }
+          },
+          {
+            "name": "builderMustBeHolder",
+            "type": {
+              "option": {
+                "defined": "Boolean"
+              }
+            }
+          },
+          {
+            "name": "updatePermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "buildPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "stakingWarmUpDuration",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingCooldownDuration",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "stakingPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "unstakingPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Permissiveness"
+                }
+              }
+            }
+          },
+          {
+            "name": "childUpdatePropagationPermissiveness",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "ChildUpdatePropagationPermissiveness"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "IncorrectOwner",
+      "msg": "Account does not have correct owner!"
+    },
+    {
+      "code": 6001,
+      "name": "Uninitialized",
+      "msg": "Account is not initialized!"
+    },
+    {
+      "code": 6002,
+      "name": "MintMismatch",
+      "msg": "Mint Mismatch!"
+    },
+    {
+      "code": 6003,
+      "name": "TokenTransferFailed",
+      "msg": "Token transfer failed"
+    },
+    {
+      "code": 6004,
+      "name": "NumericalOverflowError",
+      "msg": "Numerical overflow error"
+    },
+    {
+      "code": 6005,
+      "name": "TokenMintToFailed",
+      "msg": "Token mint to failed"
+    },
+    {
+      "code": 6006,
+      "name": "TokenBurnFailed",
+      "msg": "TokenBurnFailed"
+    },
+    {
+      "code": 6007,
+      "name": "DerivedKeyInvalid",
+      "msg": "Derived key is invalid"
+    },
+    {
+      "code": 6008,
+      "name": "MustSpecifyPermissivenessType",
+      "msg": "Update authority for metadata expected as signer"
+    },
+    {
+      "code": 6009,
+      "name": "PermissivenessNotFound",
+      "msg": "Permissiveness not found in array"
+    },
+    {
+      "code": 6010,
+      "name": "PublicKeyMismatch",
+      "msg": "Public key mismatch"
+    },
+    {
+      "code": 6011,
+      "name": "InsufficientBalance",
+      "msg": "Insufficient Balance"
+    },
+    {
+      "code": 6012,
+      "name": "MetadataDoesntExist",
+      "msg": "Metadata doesn't exist"
+    },
+    {
+      "code": 6013,
+      "name": "EditionDoesntExist",
+      "msg": "Edition doesn't exist"
+    },
+    {
+      "code": 6014,
+      "name": "NoParentPresent",
+      "msg": "No parent present"
+    },
+    {
+      "code": 6015,
+      "name": "InvalidMintAuthority",
+      "msg": "Invalid mint authority"
+    },
+    {
+      "code": 6016,
+      "name": "NotMintAuthority",
+      "msg": "Not mint authority"
+    },
+    {
+      "code": 6017,
+      "name": "MustBeHolderToBuild",
+      "msg": "Must be token holder to build against it"
+    },
+    {
+      "code": 6018,
+      "name": "MissingMerkleInfo",
+      "msg": "Missing the merkle fields"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidProof",
+      "msg": "Invalid proof"
+    },
+    {
+      "code": 6020,
+      "name": "UnableToFindValidCooldownState",
+      "msg": "Unable to find a valid cooldown state"
+    },
+    {
+      "code": 6021,
+      "name": "StakingWarmupNotStarted",
+      "msg": "You havent started staking yet"
+    },
+    {
+      "code": 6022,
+      "name": "StakingWarmupNotFinished",
+      "msg": "You havent finished your warm up period"
+    },
+    {
+      "code": 6023,
+      "name": "IncorrectStakingCounterType",
+      "msg": "Attempting to use a staking counter going in the wrong direction"
+    },
+    {
+      "code": 6024,
+      "name": "StakingCooldownNotStarted",
+      "msg": "Staking cooldown not started"
+    },
+    {
+      "code": 6025,
+      "name": "StakingCooldownNotFinished",
+      "msg": "Staking cooldown not finished"
+    },
+    {
+      "code": 6026,
+      "name": "InvalidProgramOwner",
+      "msg": "Invalid program owner"
+    },
+    {
+      "code": 6027,
+      "name": "NotInitialized",
+      "msg": "Not initialized"
+    },
+    {
+      "code": 6028,
+      "name": "StakingMintNotWhitelisted",
+      "msg": "Staking mint not whitelisted"
+    },
+    {
+      "code": 6029,
+      "name": "DiscriminatorMismatch",
+      "msg": "Discriminator mismatch"
+    },
+    {
+      "code": 6030,
+      "name": "StakingForPlayerComingSoon",
+      "msg": "Staking for player coming soon"
+    },
+    {
+      "code": 6031,
+      "name": "ArtifactLacksNamespace",
+      "msg": "Artifact not in namespace"
+    }
+  ]
+}

--- a/rust/staking/Cargo.toml
+++ b/rust/staking/Cargo.toml
@@ -21,6 +21,6 @@ arrayref = "0.3.6"
 spl-associated-token-account = { version="1.0.3", features = ["no-entrypoint"] }
 spl-token = { version="3.1.1", features = ["no-entrypoint"] }
 metaplex-token-metadata = { version="0.0.1", features = ["no-entrypoint"] }
-raindrops-namespace = { features = ["no-entrypoint"], path = "../namespace" }
-raindrops-item = { features = ["cpi", "no-entrypoint"], path = "../item" }
+raindrops-namespace-cpi = { path = "../namespace-cpi" }
+raindrops-item = { features = ["no-entrypoint", "cpi"], path = "../item" }
 raindrops-player = { features = ["no-entrypoint"], path = "../player" }

--- a/rust/staking/src/lib.rs
+++ b/rust/staking/src/lib.rs
@@ -9,10 +9,13 @@ use raindrops_item::{
         assert_permissiveness_access, close_token_account, spl_token_transfer,
         AssertPermissivenessAccessArgs, TokenTransferParams,
     },
-    Boolean, ChildUpdatePropagationPermissiveness, NamespaceAndIndex, Permissiveness,
+    Boolean, ChildUpdatePropagationPermissiveness,
     PermissivenessType,
+    Permissiveness,
 };
 use raindrops_player::program::Player;
+use raindrops_namespace_cpi::NamespaceAndIndex;
+
 anchor_lang::declare_id!("stk9HFnKhZN2PZjnn5C4wTzmeiAEgsDkbqnHkNjX1Z4");
 pub const PREFIX: &str = "staking";
 pub const STAKING_COUNTER: &str = "counter";
@@ -816,4 +819,6 @@ pub enum ErrorCode {
     DiscriminatorMismatch,
     #[msg("Staking for player coming soon")]
     StakingForPlayerComingSoon,
+    #[msg("Artifact not in namespace")]
+    ArtifactLacksNamespace
 }

--- a/rust/tests/namespace.ts
+++ b/rust/tests/namespace.ts
@@ -17,7 +17,7 @@ describe("namespace", () => {
   // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
 
-  it("init namespace", async () => {
+  it.only("init namespace", async () => {
     const payer = await newPayer(anchor.getProvider().connection);
     const namespaceProgram = await NamespaceProgram.getProgramWithConfig(
       NamespaceProgram,


### PR DESCRIPTION
This is one way we can get around the circular dependency issue with our crates.

Each crate generates a CPI crate, if one other crate needs to make CPI calls it pulls in the CPI crate not the main crate.

In this example, the namespace program instead pulls in `item-cpi`, this allows the `item` crate to pull in the `namespace` crate for all the types it expects instead of a copy/paste
