### PR TITLE
Update Staking to not need manual edit

### DIFF
--- a/js/lib/src/idls/raindrops_staking.ts
+++ b/js/lib/src/idls/raindrops_staking.ts
@@ -330,110 +330,6 @@ export type RaindropsStaking = {
           }
         ]
       }
-    },
-    {
-      "name": "artifactClass",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "namespaces",
-            "type": {
-              "option": {
-                "vec": {
-                  "defined": "NamespaceAndIndex"
-                }
-              }
-            }
-          },
-          {
-            "name": "parent",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "mint",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "metadata",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "edition",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "bump",
-            "type": "u8"
-          },
-          {
-            "name": "existingChildren",
-            "type": "u64"
-          },
-          {
-            "name": "data",
-            "type": {
-              "defined": "ArtifactClassData"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "artifact",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "namespaces",
-            "type": {
-              "option": {
-                "vec": {
-                  "defined": "NamespaceAndIndex"
-                }
-              }
-            }
-          },
-          {
-            "name": "parent",
-            "type": "publicKey"
-          },
-          {
-            "name": "mint",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "metadata",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "edition",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "bump",
-            "type": "u8"
-          },
-          {
-            "name": "tokensStaked",
-            "type": "u64"
-          }
-        ]
-      }
     }
   ],
   "types": [
@@ -663,6 +559,26 @@ export type RaindropsStaking = {
                 }
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissivenessType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenHolder"
+          },
+          {
+            "name": "ParentTokenHolder"
+          },
+          {
+            "name": "UpdateAuthority"
+          },
+          {
+            "name": "Anybody"
           }
         ]
       }
@@ -1159,110 +1075,6 @@ export const IDL: RaindropsStaking = {
           }
         ]
       }
-    },
-    {
-      "name": "artifactClass",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "namespaces",
-            "type": {
-              "option": {
-                "vec": {
-                  "defined": "NamespaceAndIndex"
-                }
-              }
-            }
-          },
-          {
-            "name": "parent",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "mint",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "metadata",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "edition",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "bump",
-            "type": "u8"
-          },
-          {
-            "name": "existingChildren",
-            "type": "u64"
-          },
-          {
-            "name": "data",
-            "type": {
-              "defined": "ArtifactClassData"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "artifact",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "namespaces",
-            "type": {
-              "option": {
-                "vec": {
-                  "defined": "NamespaceAndIndex"
-                }
-              }
-            }
-          },
-          {
-            "name": "parent",
-            "type": "publicKey"
-          },
-          {
-            "name": "mint",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "metadata",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "edition",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "bump",
-            "type": "u8"
-          },
-          {
-            "name": "tokensStaked",
-            "type": "u64"
-          }
-        ]
-      }
     }
   ],
   "types": [
@@ -1492,6 +1304,26 @@ export const IDL: RaindropsStaking = {
                 }
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissivenessType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenHolder"
+          },
+          {
+            "name": "ParentTokenHolder"
+          },
+          {
+            "name": "UpdateAuthority"
+          },
+          {
+            "name": "Anybody"
           }
         ]
       }

--- a/rust/staking/src/lib.rs
+++ b/rust/staking/src/lib.rs
@@ -102,7 +102,7 @@ pub mod raindrops_staking {
         let namespace = assert_part_of_namespace(&artifact_unchecked.to_account_info(), namespace)?;
 
         let permissiveness: Option<ItemPermissivenessType> = match staking_permissiveness_to_use {
-            Some(p) => Some(p.convert_to_item_permissiveness()),
+            Some(p) => Some(p.to_item_permissiveness()),
             None => None,
         };
 
@@ -291,7 +291,7 @@ pub mod raindrops_staking {
         )?;
 
         let permissiveness: Option<ItemPermissivenessType> = match staking_permissiveness_to_use {
-            Some(p) => Some(p.convert_to_item_permissiveness()),
+            Some(p) => Some(p.to_item_permissiveness()),
             None => None,
         };
 
@@ -771,12 +771,12 @@ pub enum PermissivenessType {
 }
 
 impl PermissivenessType {
-    pub fn convert_to_item_permissiveness(&self) -> ItemPermissivenessType {
+    pub fn to_item_permissiveness(&self) -> ItemPermissivenessType {
         match self {
-            PermissivenessType::TokenHolder => return ItemPermissivenessType::TokenHolder,
-            PermissivenessType::ParentTokenHolder => return ItemPermissivenessType::ParentTokenHolder,
-            PermissivenessType::UpdateAuthority => return ItemPermissivenessType::UpdateAuthority,
-            PermissivenessType::Anybody => return  ItemPermissivenessType::Anybody,
+            PermissivenessType::TokenHolder => ItemPermissivenessType::TokenHolder,
+            PermissivenessType::ParentTokenHolder => ItemPermissivenessType::ParentTokenHolder,
+            PermissivenessType::UpdateAuthority => ItemPermissivenessType::UpdateAuthority,
+            PermissivenessType::Anybody => ItemPermissivenessType::Anybody,
         }
     }
 }

--- a/rust/staking/src/utils.rs
+++ b/rust/staking/src/utils.rs
@@ -92,7 +92,7 @@ pub fn assert_is_proper_instance<'info>(
     artifact_class: &Pubkey,
     mint: &Pubkey,
     index: u64,
-) -> Result<Artifact> {
+) -> Result<()> {
     require!(
         artifact.owner == &raindrops_player::id() || artifact.owner == &raindrops_item::id(),
         InvalidProgramOwner
@@ -160,7 +160,7 @@ pub fn assert_is_proper_instance<'info>(
         PublicKeyMismatch
     );
 
-    Ok(instance_deserialized)
+    Ok(())
 }
 
 pub fn assert_part_of_namespace<'a, 'b>(

--- a/rust/tests/staking.ts
+++ b/rust/tests/staking.ts
@@ -1,0 +1,61 @@
+import * as anchor from "@project-serum/anchor";
+import { BN } from "@project-serum/anchor";
+import * as splToken from "../node_modules/@solana/spl-token";
+import * as mpl from "@metaplex-foundation/mpl-token-metadata";
+import {
+  State,
+  Instructions,
+  Utils,
+  Constants,
+  StakingProgram,
+  Idls,
+} from "@raindrops-protocol/raindrops";
+import assert = require("assert");
+
+describe("namespace", () => {
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  const connection = anchor.getProvider().connection;
+
+  it.only("staking smoke test", async () => {
+    const payer = await newPayer(
+      connection,
+    );
+
+    const _stakingProgram = await StakingProgram.getProgramWithConfig(
+        StakingProgram,
+        {
+          asyncSigning: false,
+          provider: new anchor.AnchorProvider(
+            connection,
+            new anchor.Wallet(payer),
+            { commitment: "confirmed" }
+          ),
+          idl: Idls.StakingIDL,
+    });
+  });
+});
+
+async function newPayer(
+  connection: anchor.web3.Connection,
+): Promise<anchor.web3.Keypair> {
+  const payer = anchor.web3.Keypair.generate();
+
+  const txSig = await connection.requestAirdrop(
+    payer.publicKey,
+    10 * anchor.web3.LAMPORTS_PER_SOL
+  );
+  await connection.confirmTransaction(txSig);
+
+  return payer;
+}
+
+async function confirmTransactions(
+  txSigs: string[],
+  connection: anchor.web3.Connection
+) {
+  for (let txSig of txSigs) {
+    connection.confirmTransaction(txSig, "finalized");
+  }
+}

--- a/rust/tests/staking.ts
+++ b/rust/tests/staking.ts
@@ -12,7 +12,7 @@ import {
 } from "@raindrops-protocol/raindrops";
 import assert = require("assert");
 
-describe("namespace", () => {
+describe("staking", () => {
   // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
 


### PR DESCRIPTION
- Remove `Artifact` and `ArtifactClass` as accounts, we dont need them in our IDL
- Copy the `PermissivenessType` over from Item and make a conversion function
- Setup program test scaffold for future PRs