### PR TITLE
✨ optional itemCollectionFile for boot_up step2

### DIFF
--- a/js/cli/example-configs/boot-up/pandaExample.json
+++ b/js/cli/example-configs/boot-up/pandaExample.json
@@ -469,6 +469,7 @@
     }
   },
   "itemImageFile": "/Users/jprince/Documents/pandaItems/",
+  "itemCollectionFile": "/Users/jprince/Documents/pandaItemCollectionImage.png",
   "collectionMint": "GoLMLLR6iSUrA6KsCrFh7f45Uq5EHFQ3p8RmzPoUH9mb",
   "index": 0,
   "itemIndex": 0,

--- a/js/lib/src/contract/boot_up.ts
+++ b/js/lib/src/contract/boot_up.ts
@@ -100,6 +100,7 @@ export interface BootUpArgs {
   existingItemClassDef: any;
   itemsName: string;
   existingCollectionForItems: PublicKey | null;
+  itemCollectionFile?: Buffer;
   masterMintHolder?: PublicKey;
   updateAuthority?: PublicKey;
   signerFunc?: (
@@ -547,6 +548,7 @@ export class BootUp {
       scope: { type, values },
       itemClassLookup,
       existingCollectionForItems,
+      itemCollectionFile,
       existingItemClassDef,
       bodyPartLayers,
       itemsName,
@@ -575,7 +577,7 @@ export class BootUp {
         await this.player.client.provider.connection.getAccountInfo(metadata);
       const metadataObj = decodeMetadata(metadataAccount.data);
       const firstUpload = await writeToImmutableStorage(
-        itemImageFile[this.createItemLookupKey(bodyPartLayers[0], traits[0])],
+        itemCollectionFile ?? itemImageFile[this.createItemLookupKey(bodyPartLayers[0], traits[0])],
         itemsName,
         metadataObj.data.creators.map((c) => ({
           address: c.address,


### PR DESCRIPTION
Similar to the item_collection_creator, this adds the option to provide a `itemCollectionFile` to use instead of the first bodyPartLayers trait's image file. Does ofc fallback to use that if none provided.