### PR TITLE
Small fix to beginItemActivation

### DIFF
--- a/js/lib/src/instructions/item.ts
+++ b/js/lib/src/instructions/item.ts
@@ -740,9 +740,10 @@ export class Instruction extends SolKitInstruction {
 
     const itemKey = (await getItemPDA(args.itemMint, args.index))[0];
 
-    const validationKey =
-      args.itemClass.object.itemClassData.config.usages?.[args.usageIndex]
-        .validation?.key;
+    const usages = args.itemClass.object.itemClassData.config?.usages;
+    const maybeSelectedUsage = usages ? usages[args.usageIndex] : null;
+    const validationKey = maybeSelectedUsage?.validation?.key;
+
     const validationProgram: PublicKey = validationKey
       ? new web3.PublicKey(validationKey)
       : SystemProgram.programId;


### PR DESCRIPTION
The JS code that the existing typescript compiles to fails to find the `validation` object in the selected ItemUsage object. This patch breaks the property access up into multiple steps.