### PR TITLE
Update Items HTTP Client Endpoints

### DIFF
--- a/js/lib/package.json
+++ b/js/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raindrops-protocol/raindrops",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "module": "./build/main.js",
   "main": "./build/main.js",
   "types": "./build/main.d.ts",

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -659,7 +659,7 @@ function createHeaders(rpcUrl: string, apiKey: string) {
 
   // if rpcUrl is provided add it to the header map
   if (rpcUrl !== "") {
-    headers["x-rpc-url"] = rpcUrl
+    headers["x-rpc-url"] = rpcUrl;
   }
 
   return headers;

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -650,7 +650,7 @@ function getMissingIngredients(
 }
 
 function createHeaders(rpcUrl: string, apiKey: string) {
-  let headers = {
+  const headers = {
     "content-type": "application/json",
     "x-api-key": apiKey,
   };

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -25,8 +25,10 @@ export class Client {
     switch (cluster) {
       case "mainnet-beta": {
         //this.baseUrl = "https://api.items.itsboots.xyz"; this points to the old api gateway still, we will update in a subsequent operation
-        this.baseUrl = "https://w2badi4dgl.execute-api.us-east-1.amazonaws.com/prod";
-        this.wsUrl = "wss://7mbqz4vp5e.execute-api.us-east-1.amazonaws.com/main";
+        this.baseUrl =
+          "https://w2badi4dgl.execute-api.us-east-1.amazonaws.com/prod";
+        this.wsUrl =
+          "wss://7mbqz4vp5e.execute-api.us-east-1.amazonaws.com/main";
         break;
       }
       case "devnet": {

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -24,7 +24,7 @@ export class Client {
 
     switch (cluster) {
       case "mainnet-beta": {
-        //this.baseUrl = "https://api.items.itsboots.xyz";
+        //this.baseUrl = "https://api.items.itsboots.xyz"; this points to the old api gateway still, we will update in a subsequent operation
         this.baseUrl = "https://w2badi4dgl.execute-api.us-east-1.amazonaws.com/prod";
         this.wsUrl = "wss://7mbqz4vp5e.execute-api.us-east-1.amazonaws.com/main";
         break;

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -652,11 +652,15 @@ function getMissingIngredients(
 }
 
 function createHeaders(rpcUrl: string, apiKey: string) {
-  const headers = {
+  let headers = {
     "content-type": "application/json",
     "x-api-key": apiKey,
-    "x-rpc-url": rpcUrl,
   };
+
+  // if rpcUrl is provided add it to the header map
+  if (rpcUrl !== "") {
+    headers["x-rpc-url"] = rpcUrl
+  }
 
   return headers;
 }

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -25,15 +25,12 @@ export class Client {
     switch (cluster) {
       case "mainnet-beta": {
         this.baseUrl = "https://api.items.itsboots.xyz";
-        this.wsUrl =
-          "wss://7mbqz4vp5e.execute-api.us-east-1.amazonaws.com/main";
+        this.wsUrl = "wss://ws.items.itsboots.xyz";
         break;
       }
       case "devnet": {
-        this.baseUrl =
-          "https://hwheczmzx7.execute-api.us-east-1.amazonaws.com/prod/";
-        this.wsUrl =
-          "wss://493dq7ya5a.execute-api.us-east-1.amazonaws.com/main";
+        this.baseUrl = "https://dev.api.items.itsboots.xyz";
+        this.wsUrl = "wss://dev.ws.items.itsboots.xyz";
         break;
       }
       case "localnet": {

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -33,9 +33,11 @@ export class Client {
       }
       case "devnet": {
         //this.baseUrl = "https://dev.api.items.itsboots.xyz"; this points to the old api gateway still in the CDK (cert is migrated), we will update in a subsequent operation
-        this.baseUrl = "https://hwheczmzx7.execute-api.us-east-1.amazonaws.com/prod";
+        this.baseUrl =
+          "https://hwheczmzx7.execute-api.us-east-1.amazonaws.com/prod";
         //this.wsUrl = "wss://dev.ws.items.itsboots.xyz"; this cert is broken
-        this.wsUrl = "wss://493dq7ya5a.execute-api.us-east-1.amazonaws.com/main";
+        this.wsUrl =
+          "wss://493dq7ya5a.execute-api.us-east-1.amazonaws.com/main";
         break;
       }
       case "localnet": {

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -35,9 +35,7 @@ export class Client {
         //this.baseUrl = "https://dev.api.items.itsboots.xyz"; this points to the old api gateway still in the CDK (cert is migrated), we will update in a subsequent operation
         this.baseUrl =
           "https://hwheczmzx7.execute-api.us-east-1.amazonaws.com/prod";
-        //this.wsUrl = "wss://dev.ws.items.itsboots.xyz"; this cert is broken
-        this.wsUrl =
-          "wss://493dq7ya5a.execute-api.us-east-1.amazonaws.com/main";
+        this.wsUrl = "wss://dev.ws.items.itsboots.xyz";
         break;
       }
       case "localnet": {

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -24,7 +24,7 @@ export class Client {
 
     switch (cluster) {
       case "mainnet-beta": {
-        //this.baseUrl = "https://api.items.itsboots.xyz"; this points to the old api gateway still, we will update in a subsequent operation
+        //this.baseUrl = "https://api.items.itsboots.xyz"; this points to the old api gateway still in the CDK and cert itself, we will update in a subsequent operation
         this.baseUrl =
           "https://w2badi4dgl.execute-api.us-east-1.amazonaws.com/prod";
         this.wsUrl =
@@ -32,8 +32,10 @@ export class Client {
         break;
       }
       case "devnet": {
-        this.baseUrl = "https://dev.api.items.itsboots.xyz";
-        this.wsUrl = "wss://dev.ws.items.itsboots.xyz";
+        //this.baseUrl = "https://dev.api.items.itsboots.xyz"; this points to the old api gateway still in the CDK (cert is migrated), we will update in a subsequent operation
+        this.baseUrl = "https://hwheczmzx7.execute-api.us-east-1.amazonaws.com/prod";
+        //this.wsUrl = "wss://dev.ws.items.itsboots.xyz"; this cert is broken
+        this.wsUrl = "wss://493dq7ya5a.execute-api.us-east-1.amazonaws.com/main";
         break;
       }
       case "localnet": {

--- a/js/lib/src/http/item.ts
+++ b/js/lib/src/http/item.ts
@@ -24,8 +24,9 @@ export class Client {
 
     switch (cluster) {
       case "mainnet-beta": {
-        this.baseUrl = "https://api.items.itsboots.xyz";
-        this.wsUrl = "wss://ws.items.itsboots.xyz";
+        //this.baseUrl = "https://api.items.itsboots.xyz";
+        this.baseUrl = "https://w2badi4dgl.execute-api.us-east-1.amazonaws.com/prod";
+        this.wsUrl = "wss://7mbqz4vp5e.execute-api.us-east-1.amazonaws.com/main";
         break;
       }
       case "devnet": {

--- a/rust/tests/itemv1.ts
+++ b/rust/tests/itemv1.ts
@@ -1162,7 +1162,6 @@ async function createItemClass(
 
       const ruleSetPda = await createRuleSet(payer, connection);
 
-      // TODO: test with a verified collection, for some reason this func fails
       ingredientMintOutput = await client.nfts().create({
         tokenStandard: mpl.TokenStandard.ProgrammableNonFungible,
         uri: "https://foo.com/bar.json",


### PR DESCRIPTION
# Summary

- Update URLs to point to the new API Gateways which require an API Key
- If rpcUrl is empty when client is initialized just use ours, this is so claynos can have a free RPC. In the future I think we remove this header entirely and just use our RPC with tight api key throttling restrictions.
- Once I can tear down the old HTTP API Gateways I can shift the cert over to the new gateways and then update this client to point to that CNAME.