### PR TITLE
Close token account when removing a trait

### DIFF
--- a/rust/avatar/src/instructions/remove_trait.rs
+++ b/rust/avatar/src/instructions/remove_trait.rs
@@ -83,7 +83,6 @@ pub fn handler(ctx: Context<RemoveTrait>) -> Result<()> {
 
     // close token account if amount is 0
     if ctx.accounts.avatar_trait_ata.amount == 0 {
-
         let close_ata_accounts = token::CloseAccount {
             account: ctx.accounts.avatar_trait_ata.to_account_info(),
             destination: ctx.accounts.payer.to_account_info(),

--- a/rust/avatar/src/instructions/remove_trait.rs
+++ b/rust/avatar/src/instructions/remove_trait.rs
@@ -78,6 +78,30 @@ pub fn handler(ctx: Context<RemoveTrait>) -> Result<()> {
         1,
     )?;
 
+    // reload account data to check token account amount
+    ctx.accounts.avatar_trait_ata.reload()?;
+
+    // close token account if amount is 0
+    if ctx.accounts.avatar_trait_ata.amount == 0 {
+
+        let close_ata_accounts = token::CloseAccount {
+            account: ctx.accounts.avatar_trait_ata.to_account_info(),
+            destination: ctx.accounts.payer.to_account_info(),
+            authority: ctx.accounts.avatar.to_account_info(),
+        };
+
+        token::close_account(CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            close_ata_accounts,
+            &[&[
+                Avatar::PREFIX.as_bytes(),
+                ctx.accounts.avatar_class.key().as_ref(),
+                ctx.accounts.avatar.mint.key().as_ref(),
+                &[*ctx.bumps.get("avatar").unwrap()],
+            ]],
+        ))?;
+    }
+
     // remove the trait_data
     let avatar_account_info = ctx.accounts.avatar.to_account_info();
     ctx.accounts.avatar.remove_trait(

--- a/rust/avatar/src/instructions/remove_trait_authority.rs
+++ b/rust/avatar/src/instructions/remove_trait_authority.rs
@@ -84,7 +84,6 @@ pub fn handler(ctx: Context<RemoveTraitAuthority>) -> Result<()> {
 
     // close token account if amount is 0
     if ctx.accounts.avatar_trait_ata.amount == 0 {
-
         let close_ata_accounts = token::CloseAccount {
             account: ctx.accounts.avatar_trait_ata.to_account_info(),
             destination: ctx.accounts.authority.to_account_info(),

--- a/rust/avatar/src/instructions/remove_trait_authority.rs
+++ b/rust/avatar/src/instructions/remove_trait_authority.rs
@@ -79,5 +79,29 @@ pub fn handler(ctx: Context<RemoveTraitAuthority>) -> Result<()> {
         ctx.accounts.system_program.clone(),
     );
 
+    // reload account data to check token account amount
+    ctx.accounts.avatar_trait_ata.reload()?;
+
+    // close token account if amount is 0
+    if ctx.accounts.avatar_trait_ata.amount == 0 {
+
+        let close_ata_accounts = token::CloseAccount {
+            account: ctx.accounts.avatar_trait_ata.to_account_info(),
+            destination: ctx.accounts.authority.to_account_info(),
+            authority: ctx.accounts.avatar.to_account_info(),
+        };
+
+        token::close_account(CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            close_ata_accounts,
+            &[&[
+                Avatar::PREFIX.as_bytes(),
+                ctx.accounts.avatar_class.key().as_ref(),
+                ctx.accounts.avatar.mint.key().as_ref(),
+                &[*ctx.bumps.get("avatar").unwrap()],
+            ]],
+        ))?;
+    }
+
     Ok(())
 }


### PR DESCRIPTION
# Summary

Close a token account when a trait is removed from an avatar and the amount is 0 to save on rent.