### PR TITLE
Fix Trait Updating to detect in progress updates

### DIFF
--- a/js/cli/package.json
+++ b/js/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raindrops-protocol/raindrops-cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "Apache-2.0",
   "bin": {
     "boot-up": "./src/boot_up.ts",

--- a/js/lib/package.json
+++ b/js/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raindrops-protocol/raindrops",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "module": "./build/main.js",
   "main": "./build/main.js",
   "types": "./build/main.d.ts",

--- a/js/lib/src/contract/avatar/rpc/avatar.ts
+++ b/js/lib/src/contract/avatar/rpc/avatar.ts
@@ -260,13 +260,19 @@ export class AvatarClient {
     // if payment details are null, add the beginUpdate instructions here and collapse into 1 txn
     const beginUpdateIxns: anchor.web3.TransactionInstruction[] = [];
     const traitData = await this.getTrait(trait);
-    if (traitData.equipPaymentDetails === null) {
+
+    // check if update state pda already exists
+    const target = new UpdateTargetEquipTrait(trait)
+    const updateState = updateStatePDA(accounts.avatar, target);
+    const updateStateData = await this.getUpdateState(updateState);
+
+    if (traitData.equipPaymentDetails === null && updateStateData === null) {
       const beginTraitUpdateAccounts: BeginUpdateAccounts = {
         avatar: accounts.avatar,
       };
 
       const beginTraitUpdateArgs: BeginUpdateArgs = {
-        updateTarget: new UpdateTargetEquipTrait(trait),
+        updateTarget: target,
       };
 
       const beginTraitUpdateTx = await this.beginUpdate(
@@ -290,11 +296,6 @@ export class AvatarClient {
     const traitSource = splToken.getAssociatedTokenAddressSync(
       accounts.traitMint,
       avatarAuthority
-    );
-
-    const updateState = updateStatePDA(
-      accounts.avatar,
-      new UpdateTargetEquipTrait(trait)
     );
 
     const tx = new anchor.web3.Transaction();
@@ -491,13 +492,20 @@ export class AvatarClient {
     // if payment details are null, add the beginUpdate instructions here and collapse into 1 txn
     const beginUpdateIxns: anchor.web3.TransactionInstruction[] = [];
     const traitData = await this.getTrait(trait);
-    if (traitData.removePaymentDetails === null) {
+
+    // check if update state pda already exists
+    const target = new UpdateTargetRemoveTrait(trait, avatarAuthority);
+    const updateState = updateStatePDA(accounts.avatar, target);
+    const updateStateData = await this.getUpdateState(updateState);
+
+    if (traitData.removePaymentDetails === null && updateStateData === null) {
+
       const beginTraitUpdateAccounts: BeginUpdateAccounts = {
         avatar: accounts.avatar,
       };
 
       const beginTraitUpdateArgs: BeginUpdateArgs = {
-        updateTarget: new UpdateTargetRemoveTrait(trait, avatarAuthority),
+        updateTarget: target,
       };
 
       const beginTraitUpdateTx = await this.beginUpdate(
@@ -511,11 +519,6 @@ export class AvatarClient {
       accounts.traitMint,
       accounts.avatar,
       true
-    );
-
-    const updateState = updateStatePDA(
-      accounts.avatar,
-      new UpdateTargetRemoveTrait(trait, avatarAuthority)
     );
 
     const traitDestination = splToken.getAssociatedTokenAddressSync(

--- a/js/lib/src/contract/avatar/rpc/avatar.ts
+++ b/js/lib/src/contract/avatar/rpc/avatar.ts
@@ -262,7 +262,7 @@ export class AvatarClient {
     const traitData = await this.getTrait(trait);
 
     // check if update state pda already exists
-    const target = new UpdateTargetEquipTrait(trait)
+    const target = new UpdateTargetEquipTrait(trait);
     const updateState = updateStatePDA(accounts.avatar, target);
     const updateStateData = await this.getUpdateState(updateState);
 
@@ -499,7 +499,6 @@ export class AvatarClient {
     const updateStateData = await this.getUpdateState(updateState);
 
     if (traitData.removePaymentDetails === null && updateStateData === null) {
-
       const beginTraitUpdateAccounts: BeginUpdateAccounts = {
         avatar: accounts.avatar,
       };


### PR DESCRIPTION
# Summary

Detect if an update state PDA has already been created for an update, this way we don't try to create and just go straight to the update of the actual trait