### PR TITLE
Fix UpdateTrait bug when selecting a Variant

### DIFF
--- a/js/cli/package.json
+++ b/js/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raindrops-protocol/raindrops-cli",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "bin": {
     "boot-up": "./src/boot_up.ts",

--- a/js/lib/package.json
+++ b/js/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raindrops-protocol/raindrops",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "module": "./build/main.js",
   "main": "./build/main.js",
   "types": "./build/main.d.ts",

--- a/js/lib/src/contract/avatar/rpc/avatar.ts
+++ b/js/lib/src/contract/avatar/rpc/avatar.ts
@@ -848,7 +848,9 @@ export class AvatarClient {
     );
 
     const ixArgs = {
-      variantMetadata: args.variantMetadata ? args.variantMetadata.formatForIx() : null,
+      variantMetadata: args.variantMetadata
+        ? args.variantMetadata.formatForIx()
+        : null,
       variantOption: args.variantOption
         ? args.variantOption.formatForIx()
         : null,

--- a/js/lib/src/contract/avatar/rpc/avatar.ts
+++ b/js/lib/src/contract/avatar/rpc/avatar.ts
@@ -848,7 +848,7 @@ export class AvatarClient {
     );
 
     const ixArgs = {
-      variantMetadata: args.variantMetadata ? args.variantMetadata : null,
+      variantMetadata: args.variantMetadata ? args.variantMetadata.formatForIx() : null,
       variantOption: args.variantOption
         ? args.variantOption.formatForIx()
         : null,
@@ -862,6 +862,8 @@ export class AvatarClient {
     };
 
     const trait = traitPDA(accounts.avatarClass, accounts.traitMint);
+
+    console.log(ixArgs);
 
     const tx = await this.program.methods
       .updateTrait(ixArgs)

--- a/js/lib/src/contract/avatar/rpc/avatar.ts
+++ b/js/lib/src/contract/avatar/rpc/avatar.ts
@@ -865,8 +865,6 @@ export class AvatarClient {
 
     const trait = traitPDA(accounts.avatarClass, accounts.traitMint);
 
-    console.log(ixArgs);
-
     const tx = await this.program.methods
       .updateTrait(ixArgs)
       .accounts({

--- a/rust/itemv2/src/state/accounts.rs
+++ b/rust/itemv2/src/state/accounts.rs
@@ -256,6 +256,12 @@ impl Build {
                 .any(|mint_data| mint_data.mint.eq(&ingredient_mint))
             {
                 build_ingredient_data.current_amount += amount;
+
+                // dont allow builders to put in more than the required amount
+                if build_ingredient_data.current_amount > build_ingredient_data.required_amount {
+                    return Err(ErrorCode::IncorrectIngredient.into())
+                };
+
                 found = true;
                 break;
             }

--- a/rust/itemv2/src/state/accounts.rs
+++ b/rust/itemv2/src/state/accounts.rs
@@ -258,19 +258,19 @@ impl Build {
                 build_ingredient_data.current_amount += amount;
 
                 // dont allow builders to put in more than the required amount
-                if build_ingredient_data.current_amount > build_ingredient_data.required_amount {
-                    return Err(ErrorCode::IncorrectIngredient.into())
-                };
+                require!(
+                    build_ingredient_data.current_amount <= build_ingredient_data.required_amount,
+                    ErrorCode::IncorrectIngredient
+                );
 
                 found = true;
                 break;
             }
         }
-        if found {
-            Ok(())
-        } else {
-            Err(ErrorCode::IncorrectIngredient.into())
-        }
+
+        require!(found, ErrorCode::IncorrectIngredient);
+
+        Ok(())
     }
 
     pub fn decrement_build_amount(&mut self, ingredient_mint: Pubkey, amount: u64) -> Result<()> {

--- a/rust/tests/itemv2.ts
+++ b/rust/tests/itemv2.ts
@@ -3172,7 +3172,7 @@ describe("itemv2", () => {
     assertRejects(addIngredientCollection(
       itemProgram,
       outputItemClass.itemClass,
-      nftItemClass.mints[0],
+      nftItemClass.mints[1],
       nftItemClass.itemClass,
       new anchor.BN(1)
     ));


### PR DESCRIPTION
# Summary

- call the variantMetadata format function so that the data will serialize properly to be put on chain
- add a check in the itemv2 contract which will error if a builder adds more than the required amount of any ingredient, this is designed to protect overzealous builders.
- added a quick test to verify it works